### PR TITLE
chore: Chromatic 배포 설정

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -18,8 +18,6 @@ jobs:
           fetch-depth: 0
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,37 @@
+name: Chromatic
+
+on:
+  push:
+    branches:
+      - dev
+  pull_request:
+    branches:
+      - dev
+
+jobs:
+  chromatic:
+    name: Run Chromatic
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run Chromatic
+        uses: chromaui/action@latest
+        with:
+          workingDir: packages/ui
+          projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          exitZeroOnChanges: true

--- a/packages/ui/.storybook/main.ts
+++ b/packages/ui/.storybook/main.ts
@@ -1,5 +1,7 @@
 import type { StorybookConfig } from '@storybook/react-vite';
 
+process.env.STORYBOOK = 'true';
+
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: ['@storybook/addon-onboarding', '@chromatic-com/storybook'],

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -28,6 +28,7 @@
     "dev": "storybook dev -p 6006",
     "build": "tsc -b && vite build",
     "build-storybook": "storybook build",
+    "chromatic": "chromatic --exit-zero-on-changes",
     "lint": "eslint .",
     "clean": "rm -rf dist"
   },
@@ -51,6 +52,7 @@
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^6",
+    "chromatic": "^16.1.0",
     "eslint": "^9",
     "eslint-plugin-react": "^7",
     "eslint-plugin-react-hooks": "^7.0.1",

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -4,15 +4,18 @@ import { resolve } from 'path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 
+const isStorybook = process.env.STORYBOOK === 'true';
+
 export default defineConfig({
   plugins: [
     tailwindcss(),
     react(),
-    dts({
-      include: ['src'],
-      rollupTypes: true,
-      tsconfigPath: './tsconfig.app.json',
-    }),
+    !isStorybook &&
+      dts({
+        include: ['src'],
+        rollupTypes: true,
+        tsconfigPath: './tsconfig.app.json',
+      }),
   ],
   build: {
     lib: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6
         version: 6.0.1(vite@8.0.3(@types/node@20.19.37)(jiti@2.6.1))
+      chromatic:
+        specifier: ^16.1.0
+        version: 16.1.0
       eslint:
         specifier: ^9
         version: 9.39.4(jiti@2.6.1)
@@ -1864,6 +1867,18 @@ packages:
 
   chromatic@13.3.5:
     resolution: {integrity: sha512-MzPhxpl838qJUo0A55osCF2ifwPbjcIPeElr1d4SHcjnHoIcg7l1syJDrAYK/a+PcCBrOGi06jPNpQAln5hWgw==}
+    hasBin: true
+    peerDependencies:
+      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
+      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+    peerDependenciesMeta:
+      '@chromatic-com/cypress':
+        optional: true
+      '@chromatic-com/playwright':
+        optional: true
+
+  chromatic@16.1.0:
+    resolution: {integrity: sha512-7xyOUXe8jfY6c+g9S/U/cbvzVXMjdhh9cVZYvDp8dDGonjiKSbWO1dzWApdYHIiF2xj29pvWQB7N5LT6967IDw==}
     hasBin: true
     peerDependencies:
       '@chromatic-com/cypress': ^0.*.* || ^1.0.0
@@ -5911,6 +5926,8 @@ snapshots:
   check-error@2.1.3: {}
 
   chromatic@13.3.5: {}
+
+  chromatic@16.1.0: {}
 
   ci-info@3.9.0: {}
 


### PR DESCRIPTION
## 📌 관련 이슈

- closes #7 

## 📝 작업 내용

- [x] Chromatic 패키지 설치
- [x] GitHub Actions 워크플로우 추가

## 🔎 자세한 설명
dev 브랜치에 push하거나 PR을 생성하면 Chromatic을 통해 Storybook UI 컴포넌트의 시각적 회귀 테스트가 자동으로 실행되도록 CI를 설정하고, GitHub Secret에 `CHROMATIC_PROJECT_TOKEN`을 등록했습니다.


## 🖼️ 스크린샷

## 💬 리뷰어에게

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
