### PR TITLE
chore: ESLint import 정렬 커스텀 그룹 설정 및 적용

### DIFF
--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -13,48 +13,52 @@ const FSD_LAYERS = [
   { type: 'shared', pattern: 'src/shared/**', mode: 'full' },
 ];
 
-export default defineConfig([
-  globalIgnores(['.next/**', 'out/**', 'build/**', 'next-env.d.ts']),
-  ...nextVitals,
-  ...nextTs,
-  ...baseConfig,
-  {
-    files: ['src/**/*.{ts,tsx}'],
-    plugins: { boundaries },
-    settings: {
-      'boundaries/elements': FSD_LAYERS,
-      'import/resolver': {
-        typescript: {
-          alwaysTryTypes: true,
+const config = [
+  ...defineConfig([
+    globalIgnores(['.next/**', 'out/**', 'build/**', 'next-env.d.ts']),
+    ...nextVitals,
+    ...nextTs,
+    {
+      files: ['src/**/*.{ts,tsx}'],
+      plugins: { boundaries },
+      settings: {
+        'boundaries/elements': FSD_LAYERS,
+        'import/resolver': {
+          typescript: {
+            alwaysTryTypes: true,
+          },
         },
       },
+      rules: {
+        'boundaries/element-types': [
+          'error',
+          {
+            default: 'disallow',
+            message:
+              '"${file.type}" 레이어에서 "${dependency.type}" 레이어를 import할 수 없습니다. (FSD 의존성 규칙 위반)',
+            rules: FSD_LAYERS.map(({ type }, index) => ({
+              from: type,
+              allow: FSD_LAYERS.slice(
+                type === 'shared' || type === 'app' ? index : index + 1,
+              ).map((l) => l.type),
+            })),
+          },
+        ],
+        'simple-import-sort/imports': [
+          'error',
+          {
+            groups: [
+              ['^react'],
+              ['^@?\\w'],
+              ...FSD_LAYERS.map(({ type }) => [`^@/${type}`]),
+              ['^\\.'],
+            ],
+          },
+        ],
+      },
     },
-    rules: {
-      'boundaries/element-types': [
-        'error',
-        {
-          default: 'disallow',
-          message:
-            '"${file.type}" 레이어에서 "${dependency.type}" 레이어를 import할 수 없습니다. (FSD 의존성 규칙 위반)',
-          rules: FSD_LAYERS.map(({ type }, index) => ({
-            from: type,
-            allow: FSD_LAYERS.slice(
-              type === 'shared' || type === 'app' ? index : index + 1,
-            ).map((l) => l.type),
-          })),
-        },
-      ],
-      'simple-import-sort/imports': [
-        'error',
-        {
-          groups: [
-            ['^react'],
-            ['^@?\\w'],
-            ...FSD_LAYERS.map(({ type }) => [`^@/${type}`]),
-            ['^\\.'],
-          ],
-        },
-      ],
-    },
-  },
-]);
+  ]),
+  ...baseConfig,
+];
+
+export default config;

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -49,6 +49,7 @@ const config = [
           'error',
           {
             groups: [
+              ['^\\u0000'],
               ['^react'],
               ['^@?\\w'],
               ...FSD_LAYERS.map(({ type }) => [`^@/${type}`]),

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -14,6 +14,7 @@ const FSD_LAYERS = [
 ];
 
 const config = [
+  ...baseConfig,
   ...defineConfig([
     globalIgnores(['.next/**', 'out/**', 'build/**', 'next-env.d.ts']),
     ...nextVitals,
@@ -58,7 +59,6 @@ const config = [
       },
     },
   ]),
-  ...baseConfig,
 ];
 
 export default config;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,6 @@
-import type { Metadata } from 'next';
-
 import './globals.css';
+
+import type { Metadata } from 'next';
 
 export const metadata: Metadata = {
   title: 'plog',

--- a/packages/config/eslint/base.js
+++ b/packages/config/eslint/base.js
@@ -8,7 +8,12 @@ export default [
       'simple-import-sort': simpleImportSort,
     },
     rules: {
-      'simple-import-sort/imports': 'error',
+      'simple-import-sort/imports': [
+        'error',
+        {
+          groups: [['^react'], ['^@?\\w'], ['^@/'], ['^\\.']],
+        },
+      ],
       'simple-import-sort/exports': 'error',
     },
   },

--- a/packages/config/eslint/base.js
+++ b/packages/config/eslint/base.js
@@ -11,7 +11,7 @@ export default [
       'simple-import-sort/imports': [
         'error',
         {
-          groups: [['^react'], ['^@?\\w'], ['^@/'], ['^\\.']],
+          groups: [['^\\u0000'], ['^react'], ['^@?\\w'], ['^@/'], ['^\\.']],
         },
       ],
       'simple-import-sort/exports': 'error',

--- a/packages/ui/.storybook/preview.ts
+++ b/packages/ui/.storybook/preview.ts
@@ -1,6 +1,6 @@
-import '../src/styles/storybook.css';
-
 import type { Preview } from '@storybook/react';
+
+import '../src/styles/storybook.css';
 
 const preview: Preview = {
   parameters: {

--- a/packages/ui/.storybook/preview.ts
+++ b/packages/ui/.storybook/preview.ts
@@ -1,6 +1,6 @@
-import type { Preview } from '@storybook/react';
-
 import '../src/styles/storybook.css';
+
+import type { Preview } from '@storybook/react';
 
 const preview: Preview = {
   parameters: {

--- a/packages/ui/eslint.config.js
+++ b/packages/ui/eslint.config.js
@@ -1,31 +1,31 @@
 import js from '@eslint/js';
 import baseConfig from '@plog/config/eslint/base';
-import { defineConfig, globalIgnores } from 'eslint/config';
+import { globalIgnores } from 'eslint/config';
 import reactPlugin from 'eslint-plugin-react';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
 
-export default defineConfig([
+export default [
   globalIgnores(['dist', 'storybook-static']),
+  js.configs.recommended,
+  ...tseslint.configs.recommended,
+  reactPlugin.configs.flat.recommended,
+  reactPlugin.configs.flat['jsx-runtime'],
+  reactHooks.configs.flat.recommended,
+  reactRefresh.configs.vite,
   {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      js.configs.recommended,
-      tseslint.configs.recommended,
-      reactPlugin.configs.flat.recommended,
-      reactPlugin.configs.flat['jsx-runtime'],
-      reactHooks.configs.flat.recommended,
-      reactRefresh.configs.vite,
-    ],
-    languageOptions: {
-      ecmaVersion: 'latest',
-      globals: globals.browser,
-    },
     settings: {
       react: { version: 'detect' },
     },
   },
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      ecmaVersion: 'latest',
+      globals: globals.browser,
+    },
+  },
   ...baseConfig,
-]);
+];

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,7 +1,8 @@
+import { type ComponentProps, forwardRef, type ReactNode } from 'react';
+
 import { Button as BaseButton } from '@base-ui/react/button';
 import { cn } from '@plog/utils';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { forwardRef, type ComponentProps, type ReactNode } from 'react';
 
 import Spinner from '@/components/Spinner';
 

--- a/packages/ui/src/components/Field.tsx
+++ b/packages/ui/src/components/Field.tsx
@@ -1,4 +1,4 @@
-import { type ReactNode, useState, useMemo } from 'react';
+import { type ReactNode, useMemo, useState } from 'react';
 
 import { Field as BaseField } from '@base-ui/react/field';
 import { cn } from '@plog/utils';

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -1,7 +1,6 @@
-import { resolve } from 'node:path';
-
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
+import { resolve } from 'node:path';
 import { defineConfig } from 'vite';
 import dts from 'vite-plugin-dts';
 import svgr from 'vite-plugin-svgr';

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["./*.ts"]
+}


### PR DESCRIPTION
## 📌 관련 이슈

- closes #13 

## 📝 작업 내용

- [x] `packages/config/eslint/base.js`에 `simple-import-sort/imports` 커스텀 그룹 설정 (`react` → 외부 패키지 → `@/` → 상대경로)
- [x] `packages/ui` 내 파일 import 순서 정렬 적용
- [x] 누락되었던 `packages/utils` TypeScript 설정 파일 추가

## 🔎 자세한 설명

- `base.js`에도 `simple-import-sort`가 활성화되어 있었지만 기본 그룹을 사용하고 있었습니다. 모든 패키지에서 import 순서(`react` → 외부 패키지 → `@/` → 상대경로)를 일관적으로 적용하기 위해 커스텀 그룹을 설정했습니다. 
- `apps/web`은 FSD 레이어 전용 그룹을 별도로 오버라이드하고 있어 영향이 없습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
