### PR TITLE
feat: Switch 공통 컴포넌트 제작

### DIFF
--- a/packages/ui/src/components/Switch.tsx
+++ b/packages/ui/src/components/Switch.tsx
@@ -1,0 +1,34 @@
+import { type ComponentProps, forwardRef } from 'react';
+
+import { Switch as BaseSwitch } from '@base-ui/react/switch';
+import { cn } from '@plog/utils';
+
+type SwitchProps = ComponentProps<typeof BaseSwitch.Root>;
+
+const Switch = forwardRef<HTMLElement, SwitchProps>(function Switch(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <BaseSwitch.Root
+      ref={ref}
+      className={cn(
+        'inline-flex h-5 w-10 cursor-pointer items-center rounded-full bg-semantic-object-subtle p-0.75 transition-colors outline-none',
+        'data-checked:bg-semantic-accent-normal',
+        'data-disabled:cursor-not-allowed data-disabled:bg-semantic-object-subtler',
+        className,
+      )}
+      {...props}
+    >
+      <BaseSwitch.Thumb
+        className={cn(
+          'block size-3.5 rounded-full bg-semantic-system-white transition-transform duration-200',
+          'data-checked:translate-x-5',
+          'data-disabled:bg-semantic-object-subtle',
+        )}
+      />
+    </BaseSwitch.Root>
+  );
+});
+
+export default Switch;

--- a/packages/ui/src/components/Switch.tsx
+++ b/packages/ui/src/components/Switch.tsx
@@ -13,7 +13,7 @@ const Switch = forwardRef<HTMLElement, SwitchProps>(function Switch(
     <BaseSwitch.Root
       ref={ref}
       className={cn(
-        'inline-flex h-5 w-10 cursor-pointer items-center rounded-full bg-semantic-object-subtle p-0.75 transition-colors outline-none',
+        'inline-flex h-5 w-10 cursor-pointer items-center rounded-full bg-semantic-object-subtle p-0.75 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-semantic-accent-normal',
         'data-checked:bg-semantic-accent-normal',
         'data-disabled:cursor-not-allowed data-disabled:bg-semantic-object-subtler',
         className,

--- a/packages/ui/src/components/Switch.tsx
+++ b/packages/ui/src/components/Switch.tsx
@@ -1,9 +1,9 @@
-import { type ComponentProps, forwardRef } from 'react';
+import { type ComponentPropsWithoutRef, forwardRef } from 'react';
 
 import { Switch as BaseSwitch } from '@base-ui/react/switch';
 import { cn } from '@plog/utils';
 
-type SwitchProps = ComponentProps<typeof BaseSwitch.Root>;
+type SwitchProps = ComponentPropsWithoutRef<typeof BaseSwitch.Root>;
 
 const Switch = forwardRef<HTMLElement, SwitchProps>(function Switch(
   { className, ...props },

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,5 +1,6 @@
 export { default as Button } from './components/Button';
 export { default as Field } from './components/Field';
 export { default as Input } from './components/Input';
+export { default as Switch } from './components/Switch';
 export { default as Textarea } from './components/Textarea';
 export * from './tokens';

--- a/packages/ui/src/stories/Switch.stories.tsx
+++ b/packages/ui/src/stories/Switch.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { useArgs } from 'storybook/internal/preview-api';
 
 import Switch from '@/components/Switch';
 
@@ -39,6 +40,22 @@ const meta: Meta<typeof Switch> = {
   args: {
     checked: false,
     disabled: false,
+  },
+
+  render: function Render(args) {
+    const [{ checked }, updateArgs] = useArgs();
+
+    const handleToggleSwitch = () => {
+      updateArgs({ checked: !checked });
+    };
+
+    return (
+      <Switch
+        {...args}
+        checked={checked}
+        onCheckedChange={handleToggleSwitch}
+      />
+    );
   },
 };
 

--- a/packages/ui/src/stories/Switch.stories.tsx
+++ b/packages/ui/src/stories/Switch.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Switch from '@/components/Switch';
+
+const meta: Meta<typeof Switch> = {
+  title: 'Components/Switch',
+  component: Switch,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          '토글 스위치 컴포넌트입니다. 활성화/비활성화 두 가지 상태를 전환할 때 사용합니다.',
+      },
+    },
+  },
+  argTypes: {
+    checked: {
+      description: '제어 컴포넌트에서 현재 체크 상태를 지정합니다.',
+      control: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    disabled: {
+      description: '비활성화 상태입니다. 클릭과 포커스 상호작용이 차단됩니다.',
+      control: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    defaultChecked: { table: { disable: true } },
+    className: { table: { disable: true } },
+    children: { table: { disable: true } },
+    onCheckedChange: { table: { disable: true } },
+  },
+  args: {
+    checked: false,
+    disabled: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Switch>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '기본 상태의 스위치입니다.',
+      },
+    },
+  },
+};
+
+export const Checked: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '체크된 상태의 스위치입니다.',
+      },
+    },
+  },
+  args: {
+    checked: true,
+  },
+};
+
+export const Disabled: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '비활성화된 상태의 스위치입니다.',
+      },
+    },
+  },
+  args: {
+    disabled: true,
+  },
+};
+
+export const CheckedDisabled: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '체크된 상태를 유지한 채 비활성화된 스위치입니다.',
+      },
+    },
+  },
+  args: {
+    checked: true,
+    disabled: true,
+  },
+};

--- a/packages/ui/src/stories/Switch.stories.tsx
+++ b/packages/ui/src/stories/Switch.stories.tsx
@@ -32,7 +32,6 @@ const meta: Meta<typeof Switch> = {
         defaultValue: { summary: 'false' },
       },
     },
-    defaultChecked: { table: { disable: true } },
     className: { table: { disable: true } },
     children: { table: { disable: true } },
     onCheckedChange: { table: { disable: true } },


### PR DESCRIPTION
## 📌 관련 이슈

- closes #15 

## 📝 작업 내용

- [x] 작업 내용

## 🔎 자세한 설명

> 게시글 공개 범위를 선택할 수 있는 `Switch` 컴포넌트를 추가했습니다.
> 
> 
> 이 컴포넌트는 렌더링과 상태 표현에만 집중하도록 구성했고, 실제 값 관리나 후속 상호작용은 상위 페이지에서 처리할 수 있도록 했습니다.
> 
> 구현은 Base UI의 `Switch`를 기반으로 감쌌고, 디자인 토큰을 사용해 기본 상태 / 체크 상태 / 비활성화 상태 스타일을 적용했습니다.
> 
> 각 state마다 스타일링은 `Switch`가 제공하는 내부 `data-checked`, `data-disabled` 속성을 활용하였습니다.
> 
> 또한 Storybook에서 상태별 UI를 바로 확인할 수 있도록 4가지 케이스를 문서화했습니다.
>

## 🖼️ 스크린샷

## 💬 리뷰어에게

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
