### PR TITLE
refactor: UI 컴포넌트 타입 및 공통 로직 개선

### DIFF
--- a/packages/ui/src/components/BottomSheet.tsx
+++ b/packages/ui/src/components/BottomSheet.tsx
@@ -35,19 +35,19 @@ const popupBaseStyles =
 const popupBleedStyles =
   'after:pointer-events-none after:absolute after:inset-x-0 after:top-[calc(100%-1px)] after:h-12 after:bg-semantic-system-white after:content-[""]';
 
-const popupPaddingStyles = [
+const popupPaddingStyles = cn(
   '[padding-bottom:max(calc(20px+env(safe-area-inset-bottom,0px)),var(--drawer-snap-point-offset,_0px))]',
   'data-[starting-style]:[padding-bottom:0] data-[ending-style]:[padding-bottom:0]',
-].join(' ');
+);
 
-const popupAnimationStyles = [
+const popupAnimationStyles = cn(
   '[transform:translateY(calc(var(--drawer-snap-point-offset,_0px)+var(--drawer-swipe-movement-y,_0px)))]',
   'transition-transform duration-400 ease-out',
   'data-[starting-style]:[transform:translateY(calc(100dvh+2px))]',
   'data-[ending-style]:[transform:translateY(calc(100dvh+2px))]',
   'data-[ending-style]:!duration-[calc(var(--drawer-swipe-strength,_1)*400ms)]',
   'data-[swiping]:cursor-grabbing data-[swiping]:duration-0 data-[swiping]:select-none',
-].join(' ');
+);
 
 function Content({
   children,

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -94,6 +94,7 @@ const Button = forwardRef<ComponentRef<typeof BaseButton>, ButtonProps>(
     ref,
   ) {
     const effectiveVariant = variant ?? 'primary';
+    const effectiveLoading = !disabled && !!loading;
 
     const spinnerColor: ComponentPropsWithoutRef<typeof Spinner>['color'] =
       effectiveVariant === 'primary' ? 'white' : 'gray';
@@ -102,16 +103,21 @@ const Button = forwardRef<ComponentRef<typeof BaseButton>, ButtonProps>(
       <BaseButton
         ref={ref}
         className={cn(
-          buttonVariants({ variant, size, fullWidth, loading }),
+          buttonVariants({
+            variant,
+            size,
+            fullWidth,
+            loading: effectiveLoading,
+          }),
           className,
         )}
         type={type}
         disabled={loading || disabled}
-        focusableWhenDisabled={loading}
-        aria-busy={loading}
+        focusableWhenDisabled={effectiveLoading}
+        aria-busy={effectiveLoading}
         {...props}
       >
-        {loading && <Spinner color={spinnerColor} />}
+        {effectiveLoading && <Spinner color={spinnerColor} />}
         {iconLeft}
         {children}
         {iconRight}

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -1,5 +1,6 @@
 import {
   type ComponentPropsWithoutRef,
+  type ComponentRef,
   forwardRef,
   type ReactNode,
 } from 'react';
@@ -71,46 +72,48 @@ type ButtonProps = ComponentPropsWithoutRef<typeof BaseButton> &
     loading?: boolean;
   };
 
-const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
-  {
-    variant,
-    size,
-    children,
-    iconLeft,
-    iconRight,
-    loading,
-    disabled,
-    fullWidth,
-    className,
-    type = 'button',
-    ...props
+const Button = forwardRef<ComponentRef<typeof BaseButton>, ButtonProps>(
+  function Button(
+    {
+      variant,
+      size,
+      children,
+      iconLeft,
+      iconRight,
+      loading,
+      disabled,
+      fullWidth,
+      className,
+      type = 'button',
+      ...props
+    },
+    ref,
+  ) {
+    const effectiveVariant = variant ?? 'primary';
+
+    const spinnerColor: ComponentPropsWithoutRef<typeof Spinner>['color'] =
+      effectiveVariant === 'primary' ? 'white' : 'gray';
+
+    return (
+      <BaseButton
+        ref={ref}
+        className={cn(
+          buttonVariants({ variant, size, fullWidth, loading }),
+          className,
+        )}
+        type={type}
+        disabled={loading || disabled}
+        focusableWhenDisabled={loading}
+        aria-busy={loading}
+        {...props}
+      >
+        {loading && <Spinner color={spinnerColor} />}
+        {iconLeft}
+        {children}
+        {iconRight}
+      </BaseButton>
+    );
   },
-  ref,
-) {
-  const effectiveVariant = variant ?? 'primary';
-
-  const spinnerColor: ComponentPropsWithoutRef<typeof Spinner>['color'] =
-    effectiveVariant === 'primary' ? 'white' : 'gray';
-
-  return (
-    <BaseButton
-      ref={ref}
-      className={cn(
-        buttonVariants({ variant, size, fullWidth, loading }),
-        className,
-      )}
-      type={type}
-      disabled={loading || disabled}
-      focusableWhenDisabled={loading}
-      aria-busy={loading}
-      {...props}
-    >
-      {loading && <Spinner color={spinnerColor} />}
-      {iconLeft}
-      {children}
-      {iconRight}
-    </BaseButton>
-  );
-});
+);
 
 export default Button;

--- a/packages/ui/src/components/Button.tsx
+++ b/packages/ui/src/components/Button.tsx
@@ -65,11 +65,15 @@ const buttonVariants = cva(
   },
 );
 
-type ButtonProps = ComponentPropsWithoutRef<typeof BaseButton> &
+type ButtonProps = Omit<
+  ComponentPropsWithoutRef<typeof BaseButton>,
+  'className'
+> &
   VariantProps<typeof buttonVariants> & {
     iconLeft?: ReactNode;
     iconRight?: ReactNode;
     loading?: boolean;
+    className?: string;
   };
 
 const Button = forwardRef<ComponentRef<typeof BaseButton>, ButtonProps>(

--- a/packages/ui/src/components/Chip.tsx
+++ b/packages/ui/src/components/Chip.tsx
@@ -1,5 +1,6 @@
 import {
   type ComponentPropsWithoutRef,
+  type ComponentRef,
   forwardRef,
   type ReactNode,
 } from 'react';
@@ -63,33 +64,35 @@ type ChipProps = Omit<
   iconRight?: ReactNode;
 };
 
-const Chip = forwardRef<HTMLButtonElement, ChipProps>(function Chip(
-  {
-    className,
-    children,
-    iconLeft,
-    iconRight,
-    size,
-    variant,
-    type = 'button',
-    ...props
+const Chip = forwardRef<ComponentRef<typeof BaseToggle>, ChipProps>(
+  function Chip(
+    {
+      className,
+      children,
+      iconLeft,
+      iconRight,
+      size,
+      variant,
+      type = 'button',
+      ...props
+    },
+    ref,
+  ) {
+    return (
+      <BaseToggle
+        ref={ref}
+        type={type}
+        className={(state) =>
+          cn(chipVariants({ pressed: state.pressed, size, variant }), className)
+        }
+        {...props}
+      >
+        {iconLeft}
+        {children}
+        {iconRight}
+      </BaseToggle>
+    );
   },
-  ref,
-) {
-  return (
-    <BaseToggle
-      ref={ref}
-      type={type}
-      className={(state) =>
-        cn(chipVariants({ pressed: state.pressed, size, variant }), className)
-      }
-      {...props}
-    >
-      {iconLeft}
-      {children}
-      {iconRight}
-    </BaseToggle>
-  );
-});
+);
 
 export default Chip;

--- a/packages/ui/src/components/Field.tsx
+++ b/packages/ui/src/components/Field.tsx
@@ -72,13 +72,11 @@ function Field({
                 : 'text-semantic-object-subtle',
             )}
           >
-            <>
-              {error ? (
-                <span role="alert">{error}</span>
-              ) : description ? (
-                <BaseField.Description>{description}</BaseField.Description>
-              ) : null}
-            </>
+            {error ? (
+              <span role="alert">{error}</span>
+            ) : description ? (
+              <BaseField.Description>{description}</BaseField.Description>
+            ) : null}
 
             {charCount !== null && (
               <span>

--- a/packages/ui/src/components/Field.tsx
+++ b/packages/ui/src/components/Field.tsx
@@ -36,7 +36,7 @@ function Field({
       required: !!required,
       onCharCountChange: setCharCount,
     }),
-    [error, disabled, required, setCharCount],
+    [error, disabled, required],
   );
 
   return (

--- a/packages/ui/src/components/Input.tsx
+++ b/packages/ui/src/components/Input.tsx
@@ -15,11 +15,10 @@ import { getFieldStateClass } from '@/utils/getFieldStateClass';
 
 type InputProps = Omit<
   ComponentPropsWithoutRef<'input'>,
-  'value' | 'defaultValue' | 'className'
+  'value' | 'defaultValue'
 > & {
   invalid?: boolean;
   trailing?: ReactNode;
-  className?: string;
 } & (
     | { value?: undefined; defaultValue?: string; onClear?: () => void }
     | { value: string; defaultValue?: never; onClear: () => void }

--- a/packages/ui/src/components/Input.tsx
+++ b/packages/ui/src/components/Input.tsx
@@ -1,4 +1,5 @@
-import React, {
+import {
+  type ChangeEvent,
   type ComponentPropsWithoutRef,
   type ComponentRef,
   forwardRef,
@@ -61,7 +62,7 @@ const Input = forwardRef<ComponentRef<typeof BaseInput>, InputProps>(
     const showClear = isFocused && hasValue;
     const hasTrailing = showClear || !!trailing;
 
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
       if (!isControlled) setInternalValue(e.target.value);
       onChange?.(e);
     };

--- a/packages/ui/src/components/Input.tsx
+++ b/packages/ui/src/components/Input.tsx
@@ -1,17 +1,15 @@
 import {
-  type ChangeEvent,
   type ComponentPropsWithoutRef,
   type ComponentRef,
   forwardRef,
   type ReactNode,
-  useState,
 } from 'react';
 
 import { Input as BaseInput } from '@base-ui/react/input';
 import { cn } from '@plog/utils';
 
 import ClearIcon from '@/assets/clear.svg?react';
-import { useFieldContext } from '@/hooks/useFieldContext';
+import { useTextInput } from '@/hooks/useTextInput';
 import { getFieldStateClass } from '@/utils/getFieldStateClass';
 
 type InputProps = Omit<
@@ -44,42 +42,43 @@ const Input = forwardRef<ComponentRef<typeof BaseInput>, InputProps>(
     ref,
   ) {
     const {
-      invalid: ctxInvalid,
-      disabled: ctxDisabled,
-      required: ctxRequired,
-    } = useFieldContext();
+      invalid,
+      effectiveDisabled,
+      effectiveRequired,
+      currentValue,
+      isFocused,
+      handleChange,
+      handleFocus,
+      handleBlur,
+      reset,
+    } = useTextInput<HTMLInputElement>({
+      value,
+      defaultValue,
+      invalid: invalidProp,
+      disabled,
+      required,
+      onChange,
+      onFocus,
+      onBlur,
+    });
 
-    const invalid = invalidProp ?? ctxInvalid;
-    const effectiveDisabled = disabled ?? ctxDisabled;
-    const effectiveRequired = required ?? ctxRequired;
-
-    const [isFocused, setIsFocused] = useState(false);
-    const [internalValue, setInternalValue] = useState(defaultValue ?? '');
-
-    const isControlled = value !== undefined;
-    const currentValue = isControlled ? value : internalValue;
     const hasValue = currentValue.length > 0;
     const showClear = isFocused && hasValue;
     const hasTrailing = showClear || !!trailing;
 
-    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-      if (!isControlled) setInternalValue(e.target.value);
-      onChange?.(e);
-    };
-
     const handleClear = () => {
-      if (!isControlled) setInternalValue('');
+      reset();
       onClear?.();
     };
 
-    const containerClass = cn(
-      'relative rounded-[12px] border transition-colors',
-      getFieldStateClass(effectiveDisabled, invalid, isFocused),
-      className,
-    );
-
     return (
-      <div className={containerClass}>
+      <div
+        className={cn(
+          'relative rounded-[12px] border transition-colors',
+          getFieldStateClass(effectiveDisabled, invalid, isFocused),
+          className,
+        )}
+      >
         <BaseInput
           ref={ref}
           aria-invalid={invalid}
@@ -87,14 +86,8 @@ const Input = forwardRef<ComponentRef<typeof BaseInput>, InputProps>(
           onChange={handleChange}
           disabled={effectiveDisabled}
           required={effectiveRequired}
-          onFocus={(e) => {
-            setIsFocused(true);
-            onFocus?.(e);
-          }}
-          onBlur={(e) => {
-            setIsFocused(false);
-            onBlur?.(e);
-          }}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
           className={cn(
             'body-md w-full bg-transparent py-3 pl-4 text-semantic-object-boldest outline-none placeholder:text-semantic-object-subtle disabled:cursor-not-allowed disabled:text-semantic-object-subtle',
             hasTrailing ? 'pr-12' : 'pr-4',

--- a/packages/ui/src/components/Input.tsx
+++ b/packages/ui/src/components/Input.tsx
@@ -1,5 +1,6 @@
 import React, {
   type ComponentPropsWithoutRef,
+  type ComponentRef,
   forwardRef,
   type ReactNode,
   useState,
@@ -24,109 +25,111 @@ type InputProps = Omit<
     | { value: string; defaultValue?: never; onClear: () => void }
   );
 
-const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
-  {
-    invalid: invalidProp,
-    trailing,
-    onClear,
-    disabled,
-    required,
-    value,
-    defaultValue,
-    onChange,
-    onFocus,
-    onBlur,
-    className,
-    ...props
-  },
-  ref,
-) {
-  const {
-    invalid: ctxInvalid,
-    disabled: ctxDisabled,
-    required: ctxRequired,
-  } = useFieldContext();
+const Input = forwardRef<ComponentRef<typeof BaseInput>, InputProps>(
+  function Input(
+    {
+      invalid: invalidProp,
+      trailing,
+      onClear,
+      disabled,
+      required,
+      value,
+      defaultValue,
+      onChange,
+      onFocus,
+      onBlur,
+      className,
+      ...props
+    },
+    ref,
+  ) {
+    const {
+      invalid: ctxInvalid,
+      disabled: ctxDisabled,
+      required: ctxRequired,
+    } = useFieldContext();
 
-  const invalid = invalidProp ?? ctxInvalid;
-  const effectiveDisabled = disabled ?? ctxDisabled;
-  const effectiveRequired = required ?? ctxRequired;
+    const invalid = invalidProp ?? ctxInvalid;
+    const effectiveDisabled = disabled ?? ctxDisabled;
+    const effectiveRequired = required ?? ctxRequired;
 
-  const [isFocused, setIsFocused] = useState(false);
-  const [internalValue, setInternalValue] = useState(defaultValue ?? '');
+    const [isFocused, setIsFocused] = useState(false);
+    const [internalValue, setInternalValue] = useState(defaultValue ?? '');
 
-  const isControlled = value !== undefined;
-  const currentValue = isControlled ? value : internalValue;
-  const hasValue = currentValue.length > 0;
-  const showClear = isFocused && hasValue;
-  const hasTrailing = showClear || !!trailing;
+    const isControlled = value !== undefined;
+    const currentValue = isControlled ? value : internalValue;
+    const hasValue = currentValue.length > 0;
+    const showClear = isFocused && hasValue;
+    const hasTrailing = showClear || !!trailing;
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (!isControlled) setInternalValue(e.target.value);
-    onChange?.(e);
-  };
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (!isControlled) setInternalValue(e.target.value);
+      onChange?.(e);
+    };
 
-  const handleClear = () => {
-    if (!isControlled) setInternalValue('');
-    onClear?.();
-  };
+    const handleClear = () => {
+      if (!isControlled) setInternalValue('');
+      onClear?.();
+    };
 
-  const containerClass = cn(
-    'relative rounded-[12px] border transition-colors',
-    getFieldStateClass(effectiveDisabled, invalid, isFocused),
-    className,
-  );
+    const containerClass = cn(
+      'relative rounded-[12px] border transition-colors',
+      getFieldStateClass(effectiveDisabled, invalid, isFocused),
+      className,
+    );
 
-  return (
-    <div className={containerClass}>
-      <BaseInput
-        ref={ref}
-        aria-invalid={invalid}
-        value={currentValue}
-        onChange={handleChange}
-        disabled={effectiveDisabled}
-        required={effectiveRequired}
-        onFocus={(e) => {
-          setIsFocused(true);
-          onFocus?.(e);
-        }}
-        onBlur={(e) => {
-          setIsFocused(false);
-          onBlur?.(e);
-        }}
-        className={cn(
-          'body-md w-full bg-transparent py-3 pl-4 text-semantic-object-boldest outline-none placeholder:text-semantic-object-subtle disabled:cursor-not-allowed disabled:text-semantic-object-subtle',
-          hasTrailing ? 'pr-12' : 'pr-4',
-        )}
-        {...props}
-      />
-
-      {(showClear || trailing) && (
-        <div className="absolute inset-y-0 right-0 flex items-center pr-4">
-          {showClear ? (
-            <button
-              type="button"
-              onMouseDown={(e) => e.preventDefault()}
-              onClick={handleClear}
-              className="cursor-pointer"
-              tabIndex={-1}
-              aria-label="입력값 초기화"
-            >
-              <ClearIcon
-                fill="currentColor"
-                className={
-                  invalid
-                    ? 'text-semantic-feedback-error-normal'
-                    : 'text-semantic-object-subtle'
-                }
-              />
-            </button>
-          ) : (
-            trailing
+    return (
+      <div className={containerClass}>
+        <BaseInput
+          ref={ref}
+          aria-invalid={invalid}
+          value={currentValue}
+          onChange={handleChange}
+          disabled={effectiveDisabled}
+          required={effectiveRequired}
+          onFocus={(e) => {
+            setIsFocused(true);
+            onFocus?.(e);
+          }}
+          onBlur={(e) => {
+            setIsFocused(false);
+            onBlur?.(e);
+          }}
+          className={cn(
+            'body-md w-full bg-transparent py-3 pl-4 text-semantic-object-boldest outline-none placeholder:text-semantic-object-subtle disabled:cursor-not-allowed disabled:text-semantic-object-subtle',
+            hasTrailing ? 'pr-12' : 'pr-4',
           )}
-        </div>
-      )}
-    </div>
-  );
-});
+          {...props}
+        />
+
+        {(showClear || trailing) && (
+          <div className="absolute inset-y-0 right-0 flex items-center pr-4">
+            {showClear ? (
+              <button
+                type="button"
+                onMouseDown={(e) => e.preventDefault()}
+                onClick={handleClear}
+                className="cursor-pointer"
+                tabIndex={-1}
+                aria-label="입력값 초기화"
+              >
+                <ClearIcon
+                  fill="currentColor"
+                  className={
+                    invalid
+                      ? 'text-semantic-feedback-error-normal'
+                      : 'text-semantic-object-subtle'
+                  }
+                />
+              </button>
+            ) : (
+              trailing
+            )}
+          </div>
+        )}
+      </div>
+    );
+  },
+);
 
 export default Input;

--- a/packages/ui/src/components/Switch.tsx
+++ b/packages/ui/src/components/Switch.tsx
@@ -1,34 +1,37 @@
-import { type ComponentPropsWithoutRef, forwardRef } from 'react';
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+} from 'react';
 
 import { Switch as BaseSwitch } from '@base-ui/react/switch';
 import { cn } from '@plog/utils';
 
 type SwitchProps = ComponentPropsWithoutRef<typeof BaseSwitch.Root>;
 
-const Switch = forwardRef<HTMLElement, SwitchProps>(function Switch(
-  { className, ...props },
-  ref,
-) {
-  return (
-    <BaseSwitch.Root
-      ref={ref}
-      className={cn(
-        'inline-flex h-5 w-10 cursor-pointer items-center rounded-full bg-semantic-object-subtle p-0.75 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-semantic-accent-normal',
-        'data-checked:bg-semantic-accent-normal',
-        'data-disabled:cursor-not-allowed data-disabled:bg-semantic-object-subtler',
-        className,
-      )}
-      {...props}
-    >
-      <BaseSwitch.Thumb
+const Switch = forwardRef<ComponentRef<typeof BaseSwitch.Root>, SwitchProps>(
+  function Switch({ className, ...props }, ref) {
+    return (
+      <BaseSwitch.Root
+        ref={ref}
         className={cn(
-          'block size-3.5 rounded-full bg-semantic-system-white transition-transform duration-200',
-          'data-checked:translate-x-5',
-          'data-disabled:bg-semantic-object-subtle',
+          'inline-flex h-5 w-10 cursor-pointer items-center rounded-full bg-semantic-object-subtle p-0.75 transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-semantic-accent-normal',
+          'data-checked:bg-semantic-accent-normal',
+          'data-disabled:cursor-not-allowed data-disabled:bg-semantic-object-subtler',
+          className,
         )}
-      />
-    </BaseSwitch.Root>
-  );
-});
+        {...props}
+      >
+        <BaseSwitch.Thumb
+          className={cn(
+            'block size-3.5 rounded-full bg-semantic-system-white transition-transform duration-200',
+            'data-checked:translate-x-5',
+            'data-disabled:bg-semantic-object-subtle',
+          )}
+        />
+      </BaseSwitch.Root>
+    );
+  },
+);
 
 export default Switch;

--- a/packages/ui/src/components/Switch.tsx
+++ b/packages/ui/src/components/Switch.tsx
@@ -7,7 +7,10 @@ import {
 import { Switch as BaseSwitch } from '@base-ui/react/switch';
 import { cn } from '@plog/utils';
 
-type SwitchProps = ComponentPropsWithoutRef<typeof BaseSwitch.Root>;
+type SwitchProps = Omit<
+  ComponentPropsWithoutRef<typeof BaseSwitch.Root>,
+  'className'
+> & { className?: string };
 
 const Switch = forwardRef<ComponentRef<typeof BaseSwitch.Root>, SwitchProps>(
   function Switch({ className, ...props }, ref) {

--- a/packages/ui/src/components/Textarea.tsx
+++ b/packages/ui/src/components/Textarea.tsx
@@ -1,4 +1,5 @@
-import React, {
+import {
+  type ChangeEvent,
   type ComponentPropsWithoutRef,
   forwardRef,
   useEffect,
@@ -57,7 +58,7 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
     const currentValue = isControlled ? value : internalValue;
     const charCount = currentValue.length;
 
-    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
       if (!isControlled) setInternalValue(e.target.value);
       onChange?.(e);
     };

--- a/packages/ui/src/components/Textarea.tsx
+++ b/packages/ui/src/components/Textarea.tsx
@@ -12,11 +12,10 @@ import { getFieldStateClass } from '@/utils/getFieldStateClass';
 
 type TextareaProps = Omit<
   ComponentPropsWithoutRef<'textarea'>,
-  'value' | 'defaultValue' | 'className'
+  'value' | 'defaultValue'
 > & {
   invalid?: boolean;
   maxLength?: number;
-  className?: string;
 } & (
     | { value?: undefined; defaultValue?: string }
     | { value: string; defaultValue?: never }

--- a/packages/ui/src/components/Textarea.tsx
+++ b/packages/ui/src/components/Textarea.tsx
@@ -1,14 +1,9 @@
-import {
-  type ChangeEvent,
-  type ComponentPropsWithoutRef,
-  forwardRef,
-  useEffect,
-  useState,
-} from 'react';
+import { type ComponentPropsWithoutRef, forwardRef, useEffect } from 'react';
 
 import { cn } from '@plog/utils';
 
 import { useFieldContext } from '@/hooks/useFieldContext';
+import { useTextInput } from '@/hooks/useTextInput';
 import { getFieldStateClass } from '@/utils/getFieldStateClass';
 
 type TextareaProps = Omit<
@@ -39,29 +34,29 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
     },
     ref,
   ) {
+    const { insideField, onCharCountChange } = useFieldContext();
+
     const {
-      insideField,
-      invalid: ctxInvalid,
-      disabled: ctxDisabled,
-      required: ctxRequired,
-      onCharCountChange,
-    } = useFieldContext();
+      invalid,
+      effectiveDisabled,
+      effectiveRequired,
+      currentValue,
+      isFocused,
+      handleChange,
+      handleFocus,
+      handleBlur,
+    } = useTextInput<HTMLTextAreaElement>({
+      value,
+      defaultValue,
+      invalid: invalidProp,
+      disabled,
+      required,
+      onChange,
+      onFocus,
+      onBlur,
+    });
 
-    const invalid = invalidProp ?? ctxInvalid;
-    const effectiveDisabled = disabled ?? ctxDisabled;
-    const effectiveRequired = required ?? ctxRequired;
-
-    const [isFocused, setIsFocused] = useState(false);
-    const [internalValue, setInternalValue] = useState(defaultValue ?? '');
-
-    const isControlled = value !== undefined;
-    const currentValue = isControlled ? value : internalValue;
     const charCount = currentValue.length;
-
-    const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
-      if (!isControlled) setInternalValue(e.target.value);
-      onChange?.(e);
-    };
 
     useEffect(() => {
       if (!insideField || maxLength === undefined) return;
@@ -83,14 +78,8 @@ const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           disabled={effectiveDisabled}
           required={effectiveRequired}
           maxLength={maxLength}
-          onFocus={(e) => {
-            setIsFocused(true);
-            onFocus?.(e);
-          }}
-          onBlur={(e) => {
-            setIsFocused(false);
-            onBlur?.(e);
-          }}
+          onFocus={handleFocus}
+          onBlur={handleBlur}
           className={cn(
             'body-md w-full resize-none rounded-[12px] border bg-transparent px-4 py-3 text-semantic-object-boldest transition-colors outline-none placeholder:text-semantic-object-subtle disabled:cursor-not-allowed disabled:text-semantic-object-subtle',
             getFieldStateClass(effectiveDisabled, invalid, isFocused),

--- a/packages/ui/src/hooks/useTextInput.ts
+++ b/packages/ui/src/hooks/useTextInput.ts
@@ -1,0 +1,72 @@
+import { type ChangeEvent, type FocusEvent, useState } from 'react';
+
+import { useFieldContext } from '@/hooks/useFieldContext';
+
+type UseTextInputOptions<T extends HTMLInputElement | HTMLTextAreaElement> = {
+  value?: string;
+  defaultValue?: string;
+  invalid?: boolean;
+  disabled?: boolean;
+  required?: boolean;
+  onChange?: (e: ChangeEvent<T>) => void;
+  onFocus?: (e: FocusEvent<T>) => void;
+  onBlur?: (e: FocusEvent<T>) => void;
+};
+
+export const useTextInput = <T extends HTMLInputElement | HTMLTextAreaElement>({
+  value,
+  defaultValue,
+  invalid: invalidProp,
+  disabled,
+  required,
+  onChange,
+  onFocus,
+  onBlur,
+}: UseTextInputOptions<T>) => {
+  const {
+    invalid: ctxInvalid,
+    disabled: ctxDisabled,
+    required: ctxRequired,
+  } = useFieldContext();
+
+  const invalid = invalidProp ?? ctxInvalid;
+  const effectiveDisabled = disabled ?? ctxDisabled;
+  const effectiveRequired = required ?? ctxRequired;
+
+  const [internalValue, setInternalValue] = useState(defaultValue ?? '');
+  const [isFocused, setIsFocused] = useState(false);
+
+  const isControlled = value !== undefined;
+  const currentValue = isControlled ? value : internalValue;
+
+  const handleChange = (e: ChangeEvent<T>) => {
+    if (!isControlled) setInternalValue(e.target.value);
+    onChange?.(e);
+  };
+
+  const handleFocus = (e: FocusEvent<T>) => {
+    setIsFocused(true);
+    onFocus?.(e);
+  };
+
+  const handleBlur = (e: FocusEvent<T>) => {
+    setIsFocused(false);
+    onBlur?.(e);
+  };
+
+  const reset = () => {
+    if (!isControlled) setInternalValue('');
+  };
+
+  return {
+    invalid,
+    effectiveDisabled,
+    effectiveRequired,
+    currentValue,
+    isFocused,
+    handleChange,
+    handleFocus,
+    handleBlur,
+    reset,
+  };
+};

--- a/packages/ui/src/hooks/useTextInput.ts
+++ b/packages/ui/src/hooks/useTextInput.ts
@@ -34,7 +34,8 @@ export const useTextInput = <T extends HTMLInputElement | HTMLTextAreaElement>({
   const effectiveRequired = required ?? ctxRequired;
 
   const [internalValue, setInternalValue] = useState(defaultValue ?? '');
-  const [isFocused, setIsFocused] = useState(false);
+  const [focused, setFocused] = useState(false);
+  const isFocused = focused && !effectiveDisabled;
 
   const isControlled = value !== undefined;
   const currentValue = isControlled ? value : internalValue;
@@ -45,12 +46,12 @@ export const useTextInput = <T extends HTMLInputElement | HTMLTextAreaElement>({
   };
 
   const handleFocus = (e: FocusEvent<T>) => {
-    setIsFocused(true);
+    setFocused(true);
     onFocus?.(e);
   };
 
   const handleBlur = (e: FocusEvent<T>) => {
-    setIsFocused(false);
+    setFocused(false);
     onBlur?.(e);
   };
 


### PR DESCRIPTION
## 📌 관련 이슈

- closes #31 

## 📝 작업 내용

- [x] `forwardRef` ref 타입을 Base UI 컴포넌트를 기준으로 수정
- [x] Base UI 컴포넌트의 `className` 타입 일관성 개선
- [x] `Input`, `Textarea` 공통 로직을 훅으로 분리
- [x] `Button` disabled 상태에서 로딩 동작 차단
- [x] 불필요한 코드 제거 및 스타일 통일

## 🔎 자세한 설명

###  ✅ `forwardRef` ref 타입을 `ComponentRef` 기반으로 수정

Base UI를 사용하는 `Button`, `Switch`, `Chip`, `Input`의 `ref` 타입이 HTML 요소로 고정되어 있어 실제 렌더링되는 요소와 타입이 어긋날 수 있었습니다. `ref` 타입을 `ComponentRef<typeof ...>`로 변경해 실제 렌더링되는 요소에 맞게 추론되도록 수정했습니다.

```ts
// Before
const Switch = forwardRef<HTMLElement, SwitchProps>(...)
const Button = forwardRef<HTMLButtonElement, ButtonProps>(...)

// After
const Switch = forwardRef<ComponentRef<typeof BaseSwitch.Root>, SwitchProps>(...)
const Button = forwardRef<ComponentRef<typeof BaseButton>, ButtonProps>(...)
```

### ✅ `className` 타입 처리 방식 통일

Base UI 컴포넌트는 `className`으로 `((state) => string)` 형태를 지원하지만, `Button`과 `Switch`는 문자열처럼 처리하고 있어 함수 전달 시 의도하지 않은 값이 생성될 수 있었습니다. `Chip`과 동일하게 `className`을 `string`으로 제한했습니다.

반대로 `Input`과 `Textarea`는 HTML 요소를 기반으로 하고 있어 이미 `className`이 `string` 타입인데, 불필요하게 Omit 후 재정의하고 있어 해당 부분을 제거했습니다.

### ✅ `useTextInput` 훅 분리

`Input`, `Textarea`에서 제어/비제어 상태, `FieldContext` 통합, 포커스 관리 로직이 중복되어 있었습니다. 이를 `useTextInput` 훅으로 추출했습니다.

### ✅ `Button`의 `disabled`과 `loading` 동작 충돌 수정

`disabled`와 `loading`이 동시에 전달될 때 로딩 기준으로 동작하던 부분을 정리했습니다. `disabled`가 명시되면 로딩 관련 동작을 모두 억제하도록 수정했습니다.

### ✅ 불필요한 코드 제거 및 스타일 통일

- `Field`의 단일 요소를 감싸는 불필요한 Fragment 제거
- `BottomSheet`의 `className` 상수 조합 시 `.join(' ')` 대신 `cn()` 사용으로 통일
- `Input`, `Textarea`에서 `React.ChangeEvent` 사용을 위한 React namespace import 제거 및  `ChangeEvent`를 named import로 변경
- `Field` 내 `useMemo`의 의존성 배열에서 `useState`의 setter 함수 제거

## 🖼️ 스크린샷

## 💬 리뷰어에게

리팩토링 이후에도 기존 동작이 유지되는지 한 번 더 확인 부탁드립니다 🫡

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
