### PR TITLE
feat: 공통 아이콘 버튼 컴포넌트 구현

### DIFF
--- a/packages/ui/src/components/IconButton.tsx
+++ b/packages/ui/src/components/IconButton.tsx
@@ -33,12 +33,15 @@ const iconButtonVariants = cva(
 
 type IconButtonProps = Omit<
   ComponentPropsWithoutRef<typeof BaseButton>,
-  'className' | 'children'
+  'className' | 'children' | 'aria-label' | 'aria-labelledby'
 > &
   VariantProps<typeof iconButtonVariants> & {
     icon: ReactNode;
     className?: string;
-  };
+  } & (
+    | { 'aria-label': string; 'aria-labelledby'?: string }
+    | { 'aria-label'?: string; 'aria-labelledby': string }
+  );
 
 const IconButton = forwardRef<ComponentRef<typeof BaseButton>, IconButtonProps>(
   function IconButton(

--- a/packages/ui/src/components/IconButton.tsx
+++ b/packages/ui/src/components/IconButton.tsx
@@ -39,8 +39,8 @@ type IconButtonProps = Omit<
     icon: ReactNode;
     className?: string;
   } & (
-    | { 'aria-label': string; 'aria-labelledby'?: string }
-    | { 'aria-label'?: string; 'aria-labelledby': string }
+    | { 'aria-label': string; 'aria-labelledby'?: never }
+    | { 'aria-label'?: never; 'aria-labelledby': string }
   );
 
 const IconButton = forwardRef<ComponentRef<typeof BaseButton>, IconButtonProps>(

--- a/packages/ui/src/components/IconButton.tsx
+++ b/packages/ui/src/components/IconButton.tsx
@@ -1,0 +1,61 @@
+import {
+  type ComponentPropsWithoutRef,
+  type ComponentRef,
+  forwardRef,
+  type ReactNode,
+} from 'react';
+
+import { Button as BaseButton } from '@base-ui/react/button';
+import { cn } from '@plog/utils';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+const iconButtonVariants = cva(
+  'inline-flex cursor-pointer items-center justify-center rounded-lg transition-colors disabled:cursor-not-allowed focus-visible:outline-2 focus-visible:outline-offset-2 [&_svg]:fill-semantic-object-normal',
+  {
+    variants: {
+      variant: {
+        outline:
+          'border border-semantic-stroke-assistive bg-semantic-system-white hover:bg-semantic-bg-deep active:bg-semantic-bg-deeper disabled:bg-semantic-bg-deep disabled:hover:bg-semantic-bg-deep disabled:active:bg-semantic-bg-deep disabled:border-semantic-stroke-subtle disabled:[&_svg]:fill-semantic-object-subtle focus-visible:outline-semantic-stroke-subtle aria-expanded:border-semantic-accent-normal aria-expanded:[&_svg]:fill-semantic-accent-normal',
+        ghost:
+          'bg-transparent hover:bg-primitive-gray-350/10 active:bg-primitive-gray-350/20 disabled:hover:bg-transparent disabled:active:bg-transparent focus-visible:outline-semantic-stroke-subtle disabled:[&_svg]:fill-primitive-gray-80 aria-expanded:[&_svg]:fill-semantic-accent-normal',
+      },
+      size: {
+        large: 'size-10 [&_svg]:size-5',
+        small: 'size-9 [&_svg]:size-4',
+      },
+    },
+    defaultVariants: {
+      variant: 'outline',
+      size: 'large',
+    },
+  },
+);
+
+type IconButtonProps = Omit<
+  ComponentPropsWithoutRef<typeof BaseButton>,
+  'className' | 'children'
+> &
+  VariantProps<typeof iconButtonVariants> & {
+    icon: ReactNode;
+    className?: string;
+  };
+
+const IconButton = forwardRef<ComponentRef<typeof BaseButton>, IconButtonProps>(
+  function IconButton(
+    { variant, size, icon, className, type = 'button', ...props },
+    ref,
+  ) {
+    return (
+      <BaseButton
+        ref={ref}
+        type={type}
+        className={cn(iconButtonVariants({ variant, size }), className)}
+        {...props}
+      >
+        {icon}
+      </BaseButton>
+    );
+  },
+);
+
+export default IconButton;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -5,6 +5,7 @@ export { default as Checkbox } from './components/Checkbox';
 export { default as Chip } from './components/Chip';
 export { default as Dialog } from './components/Dialog';
 export { default as Field } from './components/Field';
+export { default as IconButton } from './components/IconButton';
 export { default as Input } from './components/Input';
 export { default as Spinner } from './components/Spinner';
 export { default as Switch } from './components/Switch';

--- a/packages/ui/src/stories/IconButton.stories.tsx
+++ b/packages/ui/src/stories/IconButton.stories.tsx
@@ -1,0 +1,144 @@
+import { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import BlankIcon from '@/assets/blank.svg?react';
+import IconButton from '@/components/IconButton';
+
+const meta: Meta<typeof IconButton> = {
+  title: 'Components/IconButton',
+  component: IconButton,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          '아이콘을 포함하는 버튼 컴포넌트입니다. `variant`로 시각적 스타일을, `size`로 크기를 조절합니다.\n\n아이콘만 표시되므로 사용 시 `aria-label`로 버튼의 목적을 설명해야 합니다. 연결된 요소(예: 팝오버, 필터 등)의 열림 상태를 나타낼 때는 `aria-expanded`와 `aria-controls`(제어 대상 요소의 ID)를 함께 사용합니다.',
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      description: '버튼의 시각적 스타일입니다.',
+      control: 'select',
+      options: ['outline', 'ghost'],
+      table: {
+        type: { summary: "'outline' | 'ghost'" },
+        defaultValue: { summary: 'outline' },
+      },
+    },
+    size: {
+      description: '버튼 크기를 설정합니다. 아이콘 크기도 함께 조정됩니다.',
+      control: 'select',
+      options: ['large', 'small'],
+      table: {
+        type: { summary: "'large' | 'small'" },
+        defaultValue: { summary: 'large' },
+      },
+    },
+    disabled: {
+      description:
+        '비활성화 상태입니다. 클릭 이벤트가 차단되며 스타일이 변경됩니다.',
+      control: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    icon: { table: { disable: true } },
+    className: { table: { disable: true } },
+    type: { table: { disable: true } },
+  },
+  args: {
+    variant: 'outline',
+    size: 'large',
+    disabled: false,
+  },
+  render: (args) => <IconButton {...args} icon={<BlankIcon />} />,
+};
+
+export default meta;
+type Story = StoryObj<typeof IconButton>;
+
+export const Default: Story = {};
+
+export const Disabled: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '비활성화 상태에서는 클릭 이벤트가 차단됩니다.',
+      },
+    },
+  },
+  args: {
+    disabled: true,
+  },
+};
+
+export const Variants: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`outline`은 배경과 테두리가 있고, `ghost`는 배경 없이 아이콘만 표시됩니다.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="flex items-center gap-4">
+      <IconButton {...args} variant="outline" icon={<BlankIcon />} />
+      <IconButton {...args} variant="ghost" icon={<BlankIcon />} />
+    </div>
+  ),
+};
+
+export const Sizes: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '크기에 따라 버튼과 아이콘 크기가 함께 변경됩니다.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="flex items-center gap-4">
+      <IconButton {...args} size="large" icon={<BlankIcon />} />
+      <IconButton {...args} size="small" icon={<BlankIcon />} />
+    </div>
+  ),
+};
+
+export const Expanded: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`aria-expanded`로 연결된 요소의 열림 상태를 나타냅니다. `aria-controls`에 제어 대상 요소의 ID를 지정하면 스크린리더가 버튼과 연결된 요소를 인식할 수 있습니다.',
+      },
+      source: {
+        code: `const [expanded, setExpanded] = useState(false);
+
+<IconButton
+  icon={<Icon />}
+  aria-label="메뉴 열기"
+  aria-expanded={expanded}
+  aria-controls="menu-id"
+  onClick={() => setExpanded((prev) => !prev)}
+/>`,
+      },
+    },
+  },
+  render: function Render(args) {
+    const [expanded, setExpanded] = useState(false);
+
+    return (
+      <IconButton
+        {...args}
+        icon={<BlankIcon />}
+        aria-expanded={expanded}
+        onClick={() => setExpanded((prev) => !prev)}
+      />
+    );
+  },
+};

--- a/packages/ui/src/stories/IconButton.stories.tsx
+++ b/packages/ui/src/stories/IconButton.stories.tsx
@@ -46,6 +46,30 @@ const meta: Meta<typeof IconButton> = {
         defaultValue: { summary: 'false' },
       },
     },
+    'aria-label': {
+      description: '버튼의 목적을 설명하는 텍스트입니다.',
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    'aria-labelledby': {
+      description:
+        '버튼을 설명하는 외부 요소의 ID입니다. `aria-label` 대신 사용할 수 있습니다.',
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    'aria-expanded': {
+      description:
+        '연결된 요소의 열림 상태입니다. `true`일 때 accent 색상으로 강조됩니다.',
+      control: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
     icon: { table: { disable: true } },
     className: { table: { disable: true } },
     type: { table: { disable: true } },
@@ -54,6 +78,7 @@ const meta: Meta<typeof IconButton> = {
     variant: 'outline',
     size: 'large',
     disabled: false,
+    'aria-label': '아이콘 버튼',
   },
   render: (args) => <IconButton {...args} icon={<BlankIcon />} />,
 };
@@ -114,7 +139,7 @@ export const Expanded: Story = {
     docs: {
       description: {
         story:
-          '`aria-expanded`로 연결된 요소의 열림 상태를 나타냅니다. `aria-controls`에 제어 대상 요소의 ID를 지정하면 스크린리더가 버튼과 연결된 요소를 인식할 수 있습니다.',
+          '`aria-expanded`로 연결된 요소의 열림 상태를 나타낼 수 있습니다. `aria-controls`에 제어 대상 요소의 ID를 지정하면 스크린리더가 버튼과 연결된 요소를 인식할 수 있습니다.',
       },
       source: {
         code: `const [expanded, setExpanded] = useState(false);


### PR DESCRIPTION
## 📌 관련 이슈

- closes #33 

## 📝 작업 내용

- [x] `IconButton` 컴포넌트 구현
- [x] Storybook 스토리 및 autodocs 문서 작성

## 🔎 자세한 설명

> 컴포넌트의 전체적인 구조는 `Button`을 참조했습니다. (#10)

### ✅ `aria-expanded` 기반 활성 상태 처리

요구 사항에 팝오버나 필터가 열렸을 때를 나타내는 상태가 포함되어 있어 처음에는 `pressed` prop을 사용해 처리했습니다. 하지만 버튼이 눌린 상태를 유지하는 구조는 토글 버튼에 가까웠고, 일반적인 액션 버튼과 의미가 달라지는 문제가 있었습니다.

대신 `aria-expanded="true"`일 때 accent 색상이 적용되도록 했습니다. 시각 상태와 ARIA 시맨틱을 통합해 `aria-expanded` 값만으로 상태를 표현할 수 있도록 했습니다.

```tsx
// 사용 예시
<IconButton
  icon={<FilterIcon />}
  aria-expanded={isOpen}
  onClick={() => setIsOpen((prev) => !prev)}
/>
```

  ### ✅ `aria-label` 타입 강제

해당 컴포넌트는 버튼 레이블이 없어 스크린리더가 목적을 인식할 수 없습니다. 접근성 보장을 런타임이 아닌 컴파일 타임에 보장하기 위해 `aria-label` 또는 `aria-labelledby` 중 하나를 필수로 전달하도록 타입 레벨에서 강제했습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
