### PR TITLE
feat: 공통 구분선 컴포넌트 구현

### DIFF
--- a/packages/ui/src/components/Divider.tsx
+++ b/packages/ui/src/components/Divider.tsx
@@ -1,0 +1,48 @@
+import { type ComponentPropsWithoutRef } from 'react';
+
+import { cn } from '@plog/utils';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+const dividerVariants = cva('border-semantic-object-subtler', {
+  variants: {
+    thickness: {
+      small: 'border-1',
+      medium: 'border-2',
+      large: 'border-3',
+    },
+    orientation: {
+      horizontal: 'border-t w-full',
+      vertical: 'border-l h-full',
+    },
+  },
+  defaultVariants: {
+    thickness: 'small',
+    orientation: 'horizontal',
+  },
+});
+
+type DividerThickness = VariantProps<typeof dividerVariants>['thickness'];
+type DividerOrientation = VariantProps<typeof dividerVariants>['orientation'];
+
+type DividerProps = ComponentPropsWithoutRef<'div'> & {
+  thickness?: DividerThickness;
+  orientation?: DividerOrientation;
+};
+
+function Divider({
+  className,
+  thickness,
+  orientation,
+  ...props
+}: DividerProps) {
+  return (
+    <div
+      className={cn(dividerVariants({ thickness, orientation }), className)}
+      role="separator"
+      aria-orientation={orientation ?? 'horizontal'}
+      {...props}
+    />
+  );
+}
+
+export default Divider;

--- a/packages/ui/src/components/Divider.tsx
+++ b/packages/ui/src/components/Divider.tsx
@@ -3,18 +3,50 @@ import { type ComponentPropsWithoutRef } from 'react';
 import { cn } from '@plog/utils';
 import { cva, type VariantProps } from 'class-variance-authority';
 
-const dividerVariants = cva('border-semantic-object-subtler', {
+const dividerVariants = cva('border-0 border-semantic-object-subtler', {
   variants: {
     thickness: {
-      small: 'border-1',
-      medium: 'border-2',
-      large: 'border-3',
+      small: '',
+      medium: '',
+      large: '',
     },
     orientation: {
-      horizontal: 'border-t w-full',
-      vertical: 'border-l h-full',
+      horizontal: 'w-full',
+      vertical: 'h-full',
     },
   },
+  compoundVariants: [
+    {
+      thickness: 'small',
+      orientation: 'horizontal',
+      class: 'border-t-1',
+    },
+    {
+      thickness: 'medium',
+      orientation: 'horizontal',
+      class: 'border-t-2',
+    },
+    {
+      thickness: 'large',
+      orientation: 'horizontal',
+      class: 'border-t-3',
+    },
+    {
+      thickness: 'small',
+      orientation: 'vertical',
+      class: 'border-l-1',
+    },
+    {
+      thickness: 'medium',
+      orientation: 'vertical',
+      class: 'border-l-2',
+    },
+    {
+      thickness: 'large',
+      orientation: 'vertical',
+      class: 'border-l-3',
+    },
+  ],
   defaultVariants: {
     thickness: 'small',
     orientation: 'horizontal',

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -4,6 +4,7 @@ export { default as Button } from './components/Button';
 export { default as Checkbox } from './components/Checkbox';
 export { default as Chip } from './components/Chip';
 export { default as Dialog } from './components/Dialog';
+export { default as Divider } from './components/Divider';
 export { default as Field } from './components/Field';
 export { default as IconButton } from './components/IconButton';
 export { default as Input } from './components/Input';

--- a/packages/ui/src/stories/Divider.stories.tsx
+++ b/packages/ui/src/stories/Divider.stories.tsx
@@ -1,0 +1,94 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Divider from '@/components/Divider';
+
+const meta: Meta<typeof Divider> = {
+  title: 'Components/Divider',
+  component: Divider,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          '콘텐츠 영역을 구분하는 구분선 컴포넌트입니다.\n\n`role="separator"`가 기본 적용되어 스크린리더가 구분선을 인식합니다. 순수 장식 목적으로 사용하는 경우 `aria-hidden="true"`를 명시하는 것이 좋습니다.',
+      },
+    },
+  },
+  argTypes: {
+    thickness: {
+      description: '구분선의 두께를 설정합니다.',
+      control: 'select',
+      options: ['small', 'medium', 'large'],
+      table: {
+        type: { summary: "'small' | 'medium' | 'large'" },
+        defaultValue: { summary: 'small' },
+      },
+    },
+    orientation: {
+      description: '구분선의 방향을 설정합니다.',
+      control: 'select',
+      options: ['horizontal', 'vertical'],
+      table: {
+        type: { summary: "'horizontal' | 'vertical'" },
+        defaultValue: { summary: 'horizontal' },
+      },
+    },
+    className: { table: { disable: true } },
+  },
+  args: {
+    thickness: 'small',
+    orientation: 'horizontal',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Divider>;
+
+export const Default: Story = {
+  decorators: [
+    (Story, { args }) => (
+      <div
+        className={
+          args.orientation === 'vertical' ? 'flex h-32 items-center' : 'w-64'
+        }
+      >
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export const Thickness: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '두께에 따라 세 가지 스타일을 제공합니다.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="flex w-64 flex-col gap-4">
+      <Divider {...args} thickness="small" />
+      <Divider {...args} thickness="medium" />
+      <Divider {...args} thickness="large" />
+    </div>
+  ),
+};
+
+export const Vertical: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '세로 방향의 구분선입니다.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="flex h-32 items-center gap-4">
+      <span>left</span>
+      <Divider {...args} orientation="vertical" />
+      <span>right</span>
+    </div>
+  ),
+};


### PR DESCRIPTION
## 📌 관련 이슈

- closes #39 

## 📝 작업 내용

- [x] `Divider` 컴포넌트 구현
- [x] Storybook 스토리 및 autodocs 문서 작성

## 🔎 자세한 설명

### ✅ 컴포넌트 구조

```tsx
<Divider
  thickness="small" // 'small' | 'medium' | 'large'
  orientation="horizontal" // 'horizontal' | 'vertical'
/>
```

### ✅ 기본 role 설정 및 접근성 처리

`role="separator"`를 기본값으로 설정했고, `orientation` prop을 `aria-orientation`과 연동해 구분선의 방향을 전달했습니다.

`role`과 `aria-orientation`은 `...props`보다 앞에 선언되어 있어 장식용으로 사용할 경우 `aria-hidden="true"`로 오버라이드할 수 있습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
