### PR TITLE
feat: 공통 배지 컴포넌트 구현

### DIFF
--- a/packages/ui/src/components/Badge.tsx
+++ b/packages/ui/src/components/Badge.tsx
@@ -1,0 +1,118 @@
+import { type ComponentPropsWithoutRef, forwardRef } from 'react';
+
+import { cn } from '@plog/utils';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+const badgeVariants = cva('caption-md rounded-sm py-0.5 px-1.5', {
+  variants: {
+    variant: {
+      solid: 'text-semantic-system-white',
+      soft: '',
+      outline: 'bg-semantic-system-white border',
+    },
+    color: {
+      gray: '',
+      skyblue: '',
+      green: '',
+      yellow: '',
+      orange: '',
+    },
+  },
+  compoundVariants: [
+    { variant: 'solid', color: 'gray', class: 'bg-semantic-object-normal' },
+    {
+      variant: 'solid',
+      color: 'skyblue',
+      class: 'bg-semantic-theme-sky-normal',
+    },
+    { variant: 'solid', color: 'green', class: 'bg-semantic-accent-normal' },
+    {
+      variant: 'solid',
+      color: 'yellow',
+      class:
+        'bg-semantic-theme-yellow-normal text-semantic-theme-yellow-bolder',
+    },
+    {
+      variant: 'solid',
+      color: 'orange',
+      class: 'bg-semantic-theme-orange-normal',
+    },
+    {
+      variant: 'soft',
+      color: 'gray',
+      class: 'bg-primitive-gray-40 text-semantic-object-normal',
+    },
+    {
+      variant: 'soft',
+      color: 'skyblue',
+      class: 'bg-semantic-theme-sky-subtle text-semantic-theme-sky-normal',
+    },
+    {
+      variant: 'soft',
+      color: 'green',
+      class: 'bg-semantic-accent-subtler text-semantic-accent-normal',
+    },
+    {
+      variant: 'soft',
+      color: 'yellow',
+      class: 'bg-semantic-theme-yellow-subtle text-semantic-theme-yellow-bold',
+    },
+    {
+      variant: 'soft',
+      color: 'orange',
+      class:
+        'bg-semantic-theme-orange-subtle text-semantic-theme-orange-normal',
+    },
+    {
+      variant: 'outline',
+      color: 'gray',
+      class: 'border-semantic-stroke-subtle text-semantic-object-normal',
+    },
+    {
+      variant: 'outline',
+      color: 'skyblue',
+      class:
+        'border-semantic-theme-sky-alternative text-semantic-theme-sky-normal',
+    },
+    {
+      variant: 'outline',
+      color: 'green',
+      class: 'border-semantic-accent-alternative text-semantic-accent-normal',
+    },
+    {
+      variant: 'outline',
+      color: 'yellow',
+      class:
+        'border-semantic-theme-yellow-normal text-semantic-theme-yellow-bold',
+    },
+    {
+      variant: 'outline',
+      color: 'orange',
+      class:
+        'border-semantic-theme-orange-alternative text-semantic-theme-orange-normal',
+    },
+  ],
+});
+
+type BadgeVariant = NonNullable<VariantProps<typeof badgeVariants>['variant']>;
+type BadgeColor = NonNullable<VariantProps<typeof badgeVariants>['color']>;
+
+type BadgeProps = ComponentPropsWithoutRef<'span'> & {
+  variant: BadgeVariant;
+  color: BadgeColor;
+};
+
+const Badge = forwardRef<HTMLSpanElement, BadgeProps>(function Badge(
+  { className, variant, color, ...props },
+  ref,
+) {
+  return (
+    <span
+      ref={ref}
+      className={cn(badgeVariants({ variant, color }), className)}
+      {...props}
+    />
+  );
+});
+
+export default Badge;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,3 +1,4 @@
+export { default as Badge } from './components/Badge';
 export { default as BottomNavigation } from './components/BottomNavigation';
 export { default as BottomSheet } from './components/BottomSheet';
 export { default as Button } from './components/Button';

--- a/packages/ui/src/stories/Badge.stories.tsx
+++ b/packages/ui/src/stories/Badge.stories.tsx
@@ -1,0 +1,110 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Badge from '@/components/Badge';
+
+const COLORS = ['gray', 'skyblue', 'green', 'yellow', 'orange'] as const;
+
+const meta: Meta<typeof Badge> = {
+  title: 'Components/Badge',
+  component: Badge,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          '상태나 카테고리를 나타내는 배지 컴포넌트입니다. `variant`와 `color`의 조합으로 스타일을 결정합니다.\n\n배지는 항상 의미 있는 텍스트를 포함해야 하며, 알림 카운트나 처리 상태처럼 동적으로 변하는 경우에는 `role="status"`를 사용하는 것이 좋습니다.',
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      description: '배지의 스타일 형태를 설정합니다.',
+      control: 'select',
+      options: ['solid', 'soft', 'outline'],
+      table: {
+        type: { summary: "'solid' | 'soft' | 'outline'" },
+      },
+    },
+    color: {
+      description: '배지의 색상을 설정합니다.',
+      control: 'select',
+      options: COLORS,
+      table: {
+        type: { summary: "'gray' | 'skyblue' | 'green' | 'yellow' | 'orange'" },
+      },
+    },
+    children: {
+      description: '배지에 표시될 텍스트입니다.',
+      control: 'text',
+    },
+    className: { table: { disable: true } },
+  },
+  args: {
+    variant: 'solid',
+    color: 'gray',
+    children: '배지',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Badge>;
+
+export const Default: Story = {};
+
+export const Solid: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '색상별 solid 스타일입니다.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="flex gap-2">
+      {COLORS.map((color) => (
+        <Badge key={color} {...args} variant="solid" color={color}>
+          {color}
+        </Badge>
+      ))}
+    </div>
+  ),
+};
+
+export const Soft: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '색상별 soft 스타일입니다.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="flex gap-2">
+      {COLORS.map((color) => (
+        <Badge key={color} {...args} variant="soft" color={color}>
+          {color}
+        </Badge>
+      ))}
+    </div>
+  ),
+};
+
+export const Outline: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '색상별 outline 스타일입니다.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="flex gap-2">
+      {COLORS.map((color) => (
+        <Badge key={color} {...args} variant="outline" color={color}>
+          {color}
+        </Badge>
+      ))}
+    </div>
+  ),
+};


### PR DESCRIPTION
## 📌 관련 이슈

- closes #40 

## 📝 작업 내용

- [x] `Badge` 컴포넌트 구현
- [x] Storybook 스토리 및 autodocs 문서 작성

## 🔎 자세한 설명

### ✅ 컴포넌트 구조

```tsx
<Badge
  variant="solid" // 'solid' | 'soft' | 'outline'
  color="gray"    // 'gray' | 'skyblue' | 'green' | 'yellow' | 'orange'
>
  텍스트
</Badge>
```

### ✅ 접근성 처리

배지는 텍스트를 포함하므로 별도 ARIA 처리 없이도 스크린리더에서 읽힙니다. 

다만 알림 카운트나 처리 상태처럼 동적으로 변하는 경우에는 변경 내용을 사용자에게 전달할 수 있도록 사용처에서 `role="status"`와 같은 라이브 영역을 적용하도록 Storybook에 안내를 추가했습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
