### PR TITLE
feat: 공통 아바타 컴포넌트 구현

### DIFF
--- a/packages/ui/src/components/Avatar.tsx
+++ b/packages/ui/src/components/Avatar.tsx
@@ -74,6 +74,9 @@ export default function Avatar({
               src={fallbackSrc}
               alt={alt}
               className="size-full object-cover"
+              onError={(e) => {
+                e.currentTarget.style.display = 'none';
+              }}
             />
           )}
         </BaseAvatar.Fallback>

--- a/packages/ui/src/components/Avatar.tsx
+++ b/packages/ui/src/components/Avatar.tsx
@@ -1,0 +1,89 @@
+import { type ComponentPropsWithoutRef } from 'react';
+
+import { Avatar as BaseAvatar } from '@base-ui/react/avatar';
+import { cn } from '@plog/utils';
+
+import Spinner from './Spinner';
+
+type AvatarSize = 'lg' | 'md' | 'sm' | 'xs';
+
+const sizeClass: Record<AvatarSize, string> = {
+  lg: 'size-38',
+  md: 'size-24',
+  sm: 'size-20',
+  xs: 'size-12',
+};
+
+const defaultOutlineClass: Record<AvatarSize, string> = {
+  lg: 'outline-2 outline-semantic-stroke-neutral/30',
+  md: 'outline outline-semantic-stroke-neutral/30',
+  sm: 'outline outline-semantic-stroke-neutral/30',
+  xs: 'outline outline-semantic-stroke-neutral/30',
+};
+
+const selectedOutlineClass: Record<AvatarSize, string> = {
+  lg: 'outline-4 outline-semantic-accent-normal',
+  md: 'outline-3 outline-semantic-accent-normal',
+  sm: 'outline-2 outline-semantic-accent-normal',
+  xs: 'outline-2 outline-semantic-accent-normal',
+};
+
+type AvatarProps = {
+  size: AvatarSize;
+  src?: string;
+  alt: string;
+  fallbackSrc?: string;
+  selected?: boolean;
+  loading?: boolean;
+  className?: string;
+} & Omit<
+  ComponentPropsWithoutRef<typeof BaseAvatar.Root>,
+  'className' | 'render' | 'children'
+>;
+
+export default function Avatar({
+  size,
+  src,
+  alt,
+  fallbackSrc,
+  selected = false,
+  loading = false,
+  className,
+  ...props
+}: AvatarProps) {
+  const spinnerSize = size === 'xs' ? 'small' : 'large';
+
+  return (
+    <span className={cn('relative inline-flex shrink-0', sizeClass[size])}>
+      <BaseAvatar.Root
+        className={cn(
+          'inline-flex size-full items-center justify-center overflow-hidden rounded-full bg-semantic-bg-deeper',
+          selected ? selectedOutlineClass[size] : defaultOutlineClass[size],
+          className,
+        )}
+        {...props}
+      >
+        <BaseAvatar.Image
+          src={src}
+          alt={alt}
+          className="size-full object-cover"
+        />
+        <BaseAvatar.Fallback className="size-full bg-semantic-bg-deep">
+          {fallbackSrc && (
+            <img
+              src={fallbackSrc}
+              alt={alt}
+              className="size-full object-cover"
+            />
+          )}
+        </BaseAvatar.Fallback>
+
+        {loading && (
+          <span className="absolute inset-0 flex items-center justify-center rounded-full bg-semantic-system-black/40">
+            <Spinner size={spinnerSize} color="white" />
+          </span>
+        )}
+      </BaseAvatar.Root>
+    </span>
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,3 +1,4 @@
+export { default as Avatar } from './components/Avatar';
 export { default as Badge } from './components/Badge';
 export { default as BottomNavigation } from './components/BottomNavigation';
 export { default as BottomSheet } from './components/BottomSheet';

--- a/packages/ui/src/stories/Avatar.stories.tsx
+++ b/packages/ui/src/stories/Avatar.stories.tsx
@@ -1,0 +1,151 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Avatar from '@/components/Avatar';
+
+const SAMPLE_SRC =
+  'https://images.unsplash.com/photo-1735989967755-706e5edcb44b?q=80&w=400&auto=format&fit=crop';
+
+const meta: Meta<typeof Avatar> = {
+  title: 'Components/Avatar',
+  component: Avatar,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component: '사용자 프로필 사진을 표시하는 컴포넌트입니다.',
+      },
+    },
+  },
+  argTypes: {
+    size: {
+      description: '아바타 크기를 설정합니다.',
+      control: 'select',
+      options: ['lg', 'md', 'sm', 'xs'],
+      table: {
+        type: { summary: "'lg' | 'md' | 'sm' | 'xs'" },
+      },
+    },
+    src: {
+      description: '표시할 이미지 URL입니다.',
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    fallbackSrc: {
+      description:
+        '이미지 로드 실패 시 표시할 폴백 이미지 URL입니다. 없으면 회색 원이 표시됩니다.',
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    alt: {
+      description: '이미지의 대체 텍스트입니다.',
+      control: 'text',
+      table: {
+        type: { summary: 'string' },
+      },
+    },
+    selected: {
+      description: '선택된 상태입니다. 초록색 테두리가 표시됩니다.',
+      control: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    loading: {
+      description:
+        '업로드 중 오버레이를 표시합니다. `xs` 크기에서는 작은 스피너를 사용합니다.',
+      control: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    className: { table: { disable: true } },
+  },
+  args: {
+    size: 'md',
+    src: SAMPLE_SRC,
+    alt: '사용자 프로필',
+    selected: false,
+    loading: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Avatar>;
+
+export const Default: Story = {};
+
+export const Fallback: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`src`가 없거나 이미지 로드에 실패하면 폴백 이미지를 표시합니다. `fallbackSrc`가 없으면 회색 원을 표시합니다.',
+      },
+    },
+  },
+  args: {
+    src: undefined,
+  },
+};
+
+export const Sizes: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '네 가지 크기를 제공합니다.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="flex items-end gap-6">
+      {(['lg', 'md', 'sm', 'xs'] as const).map((size) => (
+        <div key={size} className="flex flex-col items-center gap-2">
+          <Avatar {...args} size={size} />
+          <span className="caption-md text-semantic-object-normal">{size}</span>
+        </div>
+      ))}
+    </div>
+  ),
+};
+
+export const Selected: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '`selected`가 `true`이면 테두리가 표시됩니다.',
+      },
+    },
+  },
+  args: {
+    selected: true,
+  },
+};
+
+export const Loading: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '`loading`이 `true`이면 오버레이와 스피너가 표시됩니다.',
+      },
+    },
+  },
+  render: (args) => (
+    <div className="flex items-end gap-6">
+      <div className="flex flex-col items-center gap-2">
+        <Avatar {...args} size="lg" loading />
+        <span className="caption-md text-semantic-object-normal">lg</span>
+      </div>
+      <div className="flex flex-col items-center gap-2">
+        <Avatar {...args} size="xs" loading />
+        <span className="caption-md text-semantic-object-normal">xs</span>
+      </div>
+    </div>
+  ),
+};


### PR DESCRIPTION
## 📌 관련 이슈

- closes #44 

## 📝 작업 내용

- [x] `Avatar` 공통 컴포넌트 구현
- [x] Storybook 스토리 및 autodocs 문서 작성

## 🔎 자세한 설명

### ✅ 컴포넌트 구조

```tsx
<Avatar
  size="md"          // 'lg' | 'md' | 'sm' | 'xs'
  src="..."          // 프로필 이미지 URL
  alt="사용자 이름"     // 필수값
  fallbackSrc="..."  // 이미지 로드 실패 시 표시할 이미지 (없으면 회색 원)
  selected           // 선택 상태 (accent 색상 outline)
  loading            // 업로드 중 오버레이 + 스피너
/>
```

### ✅ Fallback 처리

이미지 로드 실패 시 두 단계로 fallback 되도록 처리했습니다.

1. `fallbackSrc`가 있으면 해당 이미지를 표시
2. `fallbackSrc`도 없거나 로드 실패 시 회색 원을 표시

서비스 기본 프로필 이미지가 있는 경우 `fallbackSrc`로 지정하고, 없으면 별도 처리 없이 회색 원이 표시됩니다.

### ✅ `badge` prop 미구현

디자인 시안에는 아바타 우하단에 아이콘 배지가 포함되어 있었습니다. 하지만 실제 사용 맥락에서 이 배지는 프로필 사진 편집 버튼 같은 **액션 버튼**으로, 아바타 자체의 상태가 아닌 특정 페이지의 관심사로 판단했습니다.

디자인 시스템 컴포넌트에 액션을 결합하면 버튼 클릭 핸들러 등 인터랙션도 함께 묶이면서 접근성 처리까지 복잡해질 것으로 생각했습니다.

따라서 `badge` prop은 구현하지 않았습니다. 편집 버튼이 필요한 경우 사용처에서 `relative` 컨테이너로 Avatar를 감싸고 버튼을 직접 배치하는 방식을 사용해 주세요.

### ✅ `alt` 필수값 처리

`alt`를 필수 prop으로 지정해 어떤 경우든 사용처에서 의도를 명확히 하도록 강제했습니다.

- 의미 있는 이미지라면 ``alt={`${username} 프로필 사진`}`` 처럼 설명 텍스트를 전달
- 순수 장식용이라면 `alt=""` 을 명시적으로 전달

## 🖼️ 스크린샷

## 💬 리뷰어에게

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
