### PR TITLE
feat: 공통 시간 선택 컴포넌트 구현

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -41,6 +41,7 @@
     "@plog/utils": "workspace:^",
     "class-variance-authority": "^0.7.1",
     "pretendard": "^1.3.9",
+    "swiper": "^12.1.3",
     "tailwindcss": "^4"
   },
   "devDependencies": {

--- a/packages/ui/src/components/TimePicker/TimePicker.stories.tsx
+++ b/packages/ui/src/components/TimePicker/TimePicker.stories.tsx
@@ -1,0 +1,83 @@
+import { useState } from 'react';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import TimePicker from './TimePicker';
+import type { TimeValue } from './TimePicker.types';
+
+const meta: Meta<typeof TimePicker> = {
+  title: 'Components/TimePicker',
+  component: TimePicker,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          '스와이프로 시간을 선택하는 컴포넌트입니다. `onChange`로 선택된 시간을 반환할 수 있으며, `hour`는 24시간 기준으로 반환됩니다.',
+      },
+    },
+  },
+  argTypes: {
+    defaultValue: {
+      description: '초기 시간을 지정합니다. 비제어 컴포넌트에서만 사용합니다.',
+      table: {
+        type: { summary: '{ hour: number; minute: number }' },
+      },
+    },
+    value: { table: { disable: true } },
+    onChange: { table: { disable: true } },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithDefaultValue: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '`defaultValue`로 초기 시간을 지정할 수 있습니다.',
+      },
+    },
+  },
+  args: {
+    defaultValue: { hour: 14, minute: 30 },
+  },
+};
+
+export const ReturnValue: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '`onChange`로 선택된 시간을 반환할 수 있습니다.',
+      },
+      source: {
+        code: `const [time, setTime] = useState<TimeValue>({ hour: 0, minute: 0 });
+
+return (
+  <div className="flex flex-col items-center gap-3">
+    <TimePicker onChange={setTime} />
+    <p className="body-md text-semantic-object-boldest">
+      {\`선택된 시간은 \${time.hour}시\${time.minute !== 0 ? \` \${time.minute}분\` : ''}입니다.\`}
+    </p>
+  </div>
+);`,
+      },
+    },
+  },
+  render: function Render() {
+    const [time, setTime] = useState<TimeValue>({ hour: 0, minute: 0 });
+
+    return (
+      <div className="flex flex-col items-center gap-3">
+        <TimePicker onChange={setTime} />
+        <p className="body-md text-semantic-object-boldest">
+          {`선택된 시간은 ${time.hour}시${time.minute !== 0 ? ` ${time.minute}분` : ''}입니다.`}
+        </p>
+      </div>
+    );
+  },
+};

--- a/packages/ui/src/components/TimePicker/TimePicker.tsx
+++ b/packages/ui/src/components/TimePicker/TimePicker.tsx
@@ -63,30 +63,27 @@ function TimePicker({
         aria-hidden="true"
         className="absolute h-10 w-66 rounded-lg bg-semantic-feedback-success-subtle"
       />
-      <div aria-label="오전/오후">
-        <TimePickerColumn
-          items={['오전', '오후'] as const}
-          selectedIndex={meridiemIndex}
-          onChange={(i) =>
-            update({ hour: indexToHour(hourToIndex(current.hour), i) })
-          }
-          loop={false}
-        />
-      </div>
-      <div aria-label="시">
-        <TimePickerColumn
-          items={HOURS}
-          selectedIndex={hourToIndex(current.hour)}
-          onChange={(i) => update({ hour: indexToHour(i, meridiemIndex) })}
-        />
-      </div>
-      <div aria-label="분">
-        <TimePickerColumn
-          items={MINUTES}
-          selectedIndex={current.minute}
-          onChange={(i) => update({ minute: i })}
-        />
-      </div>
+      <TimePickerColumn
+        aria-label="오전/오후"
+        items={['오전', '오후'] as const}
+        selectedIndex={meridiemIndex}
+        onChange={(i) =>
+          update({ hour: indexToHour(hourToIndex(current.hour), i) })
+        }
+        loop={false}
+      />
+      <TimePickerColumn
+        aria-label="시"
+        items={HOURS}
+        selectedIndex={hourToIndex(current.hour)}
+        onChange={(i) => update({ hour: indexToHour(i, meridiemIndex) })}
+      />
+      <TimePickerColumn
+        aria-label="분"
+        items={MINUTES}
+        selectedIndex={current.minute}
+        onChange={(i) => update({ minute: i })}
+      />
     </div>
   );
 }

--- a/packages/ui/src/components/TimePicker/TimePicker.tsx
+++ b/packages/ui/src/components/TimePicker/TimePicker.tsx
@@ -1,0 +1,94 @@
+import { useState } from 'react';
+
+import type { TimeValue } from './TimePicker.types';
+import TimePickerColumn from './TimePickerColumn';
+
+type TimePickerProps = {
+  defaultValue?: TimeValue;
+  value?: TimeValue;
+  onChange?: (value: TimeValue) => void;
+} & (
+  | { 'aria-label'?: string; 'aria-labelledby'?: never }
+  | { 'aria-label'?: never; 'aria-labelledby'?: string }
+);
+
+const HOURS = Array.from({ length: 12 }, (_, i) =>
+  String(i + 1).padStart(2, '0'),
+);
+const MINUTES = Array.from({ length: 60 }, (_, i) =>
+  String(i).padStart(2, '0'),
+);
+
+function hourToIndex(hour24: number): number {
+  const h12 = hour24 % 12;
+  return h12 === 0 ? 11 : h12 - 1;
+}
+
+function indexToHour(hourIndex: number, meridiemIndex: number): number {
+  const h12 = hourIndex + 1;
+  if (meridiemIndex === 0) return h12 === 12 ? 0 : h12;
+  return h12 === 12 ? 12 : h12 + 12;
+}
+
+function TimePicker({
+  defaultValue,
+  value,
+  onChange,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+}: TimePickerProps) {
+  const isControlled = value !== undefined;
+  const [internalValue, setInternalValue] = useState<TimeValue>(
+    defaultValue ?? { hour: 0, minute: 0 },
+  );
+
+  const current = isControlled ? value : internalValue;
+
+  const update = (partial: Partial<TimeValue>) => {
+    const next = { ...current, ...partial };
+    if (!isControlled) setInternalValue(next);
+    onChange?.(next);
+  };
+
+  const meridiemIndex = current.hour < 12 ? 0 : 1;
+
+  return (
+    <div
+      role="group"
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      className="inline-flex items-center justify-center gap-6"
+    >
+      <div
+        aria-hidden="true"
+        className="absolute h-10 w-66 rounded-lg bg-semantic-feedback-success-subtle"
+      />
+      <div aria-label="오전/오후">
+        <TimePickerColumn
+          items={['오전', '오후'] as const}
+          selectedIndex={meridiemIndex}
+          onChange={(i) =>
+            update({ hour: indexToHour(hourToIndex(current.hour), i) })
+          }
+          loop={false}
+        />
+      </div>
+      <div aria-label="시">
+        <TimePickerColumn
+          items={HOURS}
+          selectedIndex={hourToIndex(current.hour)}
+          onChange={(i) => update({ hour: indexToHour(i, meridiemIndex) })}
+        />
+      </div>
+      <div aria-label="분">
+        <TimePickerColumn
+          items={MINUTES}
+          selectedIndex={current.minute}
+          onChange={(i) => update({ minute: i })}
+        />
+      </div>
+    </div>
+  );
+}
+
+export default TimePicker;

--- a/packages/ui/src/components/TimePicker/TimePicker.tsx
+++ b/packages/ui/src/components/TimePicker/TimePicker.tsx
@@ -51,11 +51,14 @@ function TimePicker({
   };
 
   const meridiemIndex = current.hour < 12 ? 0 : 1;
+  const effectiveAriaLabel = ariaLabelledBy
+    ? ariaLabel
+    : (ariaLabel ?? '시간 선택');
 
   return (
     <div
       role="group"
-      aria-label={ariaLabel}
+      aria-label={effectiveAriaLabel}
       aria-labelledby={ariaLabelledBy}
       className="relative inline-flex items-center justify-center gap-6"
     >

--- a/packages/ui/src/components/TimePicker/TimePicker.tsx
+++ b/packages/ui/src/components/TimePicker/TimePicker.tsx
@@ -57,7 +57,7 @@ function TimePicker({
       role="group"
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledBy}
-      className="inline-flex items-center justify-center gap-6"
+      className="relative inline-flex items-center justify-center gap-6"
     >
       <div
         aria-hidden="true"

--- a/packages/ui/src/components/TimePicker/TimePicker.types.ts
+++ b/packages/ui/src/components/TimePicker/TimePicker.types.ts
@@ -1,0 +1,4 @@
+export type TimeValue = {
+  hour: number;
+  minute: number;
+};

--- a/packages/ui/src/components/TimePicker/TimePickerColumn.tsx
+++ b/packages/ui/src/components/TimePicker/TimePickerColumn.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useRef } from 'react';
+
+import { cn } from '@plog/utils';
+import type { Swiper as SwiperType } from 'swiper';
+import { FreeMode } from 'swiper/modules';
+import { Swiper, SwiperSlide } from 'swiper/react';
+
+const SLIDE_HEIGHT = 40;
+const VISIBLE_COUNT = 3;
+
+type TimePickerColumnProps = {
+  items: readonly string[];
+  selectedIndex: number;
+  onChange: (index: number) => void;
+  loop?: boolean;
+};
+
+function TimePickerColumn({
+  items,
+  selectedIndex,
+  onChange,
+  loop = true,
+}: TimePickerColumnProps) {
+  const swiperRef = useRef<SwiperType | null>(null);
+
+  useEffect(() => {
+    if (!swiperRef.current) return;
+    const swiper = swiperRef.current;
+    if (swiper.realIndex !== selectedIndex) {
+      if (loop) {
+        swiper.slideToLoop(selectedIndex, 0);
+      } else {
+        swiper.slideTo(selectedIndex, 0);
+      }
+    }
+  }, [selectedIndex, loop]);
+
+  return (
+    <div
+      role="listbox"
+      className="relative overflow-hidden"
+      style={{ height: SLIDE_HEIGHT * VISIBLE_COUNT }}
+    >
+      <Swiper
+        direction="vertical"
+        modules={[FreeMode]}
+        loop={loop}
+        slidesPerView={VISIBLE_COUNT}
+        centeredSlides
+        slideToClickedSlide
+        initialSlide={selectedIndex}
+        onSwiper={(swiper) => {
+          swiperRef.current = swiper;
+        }}
+        onSlideChange={(swiper) => onChange(swiper.realIndex)}
+        className="h-full"
+      >
+        {items.map((item) => (
+          <SwiperSlide
+            key={item}
+            className="flex w-14 cursor-pointer items-center justify-center select-none"
+          >
+            {({ isActive }) => (
+              <span
+                role="option"
+                aria-selected={isActive}
+                className={cn(
+                  'body-lg',
+                  isActive
+                    ? 'text-semantic-object-boldest'
+                    : 'text-semantic-object-subtle',
+                )}
+              >
+                {item}
+              </span>
+            )}
+          </SwiperSlide>
+        ))}
+      </Swiper>
+    </div>
+  );
+}
+
+export default TimePickerColumn;

--- a/packages/ui/src/components/TimePicker/TimePickerColumn.tsx
+++ b/packages/ui/src/components/TimePicker/TimePickerColumn.tsx
@@ -30,9 +30,9 @@ function TimePickerColumn({
     const swiper = swiperRef.current;
     if (swiper.realIndex !== selectedIndex) {
       if (loop) {
-        swiper.slideToLoop(selectedIndex, 0);
+        swiper.slideToLoop(selectedIndex, 0, false);
       } else {
-        swiper.slideTo(selectedIndex, 0);
+        swiper.slideTo(selectedIndex, 0, false);
       }
     }
   }, [selectedIndex, loop]);

--- a/packages/ui/src/components/TimePicker/TimePickerColumn.tsx
+++ b/packages/ui/src/components/TimePicker/TimePickerColumn.tsx
@@ -13,6 +13,7 @@ type TimePickerColumnProps = {
   selectedIndex: number;
   onChange: (index: number) => void;
   loop?: boolean;
+  'aria-label'?: string;
 };
 
 function TimePickerColumn({
@@ -20,6 +21,7 @@ function TimePickerColumn({
   selectedIndex,
   onChange,
   loop = true,
+  'aria-label': ariaLabel,
 }: TimePickerColumnProps) {
   const swiperRef = useRef<SwiperType | null>(null);
 
@@ -38,6 +40,7 @@ function TimePickerColumn({
   return (
     <div
       role="listbox"
+      aria-label={ariaLabel}
       className="relative overflow-hidden"
       style={{ height: SLIDE_HEIGHT * VISIBLE_COUNT }}
     >

--- a/packages/ui/src/components/TimePicker/index.ts
+++ b/packages/ui/src/components/TimePicker/index.ts
@@ -1,0 +1,2 @@
+export { default as TimePicker } from './TimePicker';
+export type { TimeValue } from './TimePicker.types';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -15,5 +15,6 @@ export * from './components/Spinner';
 export * from './components/Switch';
 export * from './components/Tab';
 export * from './components/Textarea';
+export * from './components/TimePicker';
 export * from './components/Toast';
 export * from './tokens';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -136,6 +136,9 @@ importers:
       pretendard:
         specifier: ^1.3.9
         version: 1.3.9
+      swiper:
+        specifier: ^12.1.3
+        version: 12.1.3
       tailwindcss:
         specifier: ^4
         version: 4.2.2
@@ -4097,6 +4100,10 @@ packages:
 
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
+
+  swiper@12.1.3:
+    resolution: {integrity: sha512-XcWlVmkHFICI4fuoJKgbp8PscDcS4i7pBH8nwJRBi3dpQvhCySwsWRYm4bOf/BzKVWkHOYaFw7qz9uBSrY3oug==}
+    engines: {node: '>= 4.7.0'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -8686,6 +8693,8 @@ snapshots:
   supports-preserve-symlinks-flag@1.0.0: {}
 
   svg-parser@2.0.4: {}
+
+  swiper@12.1.3: {}
 
   symbol-tree@3.2.4: {}
 


### PR DESCRIPTION
## 📌 관련 이슈

- closes #48 

## 📝 작업 내용

- [x] `TimePicker` 공통 컴포넌트 구현
- [x] Storybook 스토리 및 autodocs 문서 작성

## 🔎 자세한 설명

### ✅ 컴포넌트 구조

```tsx
<TimePicker
  defaultValue={{ hour: 14, minute: 30 }}   // 비제어 초기값
  value={time}                              // 제어 모드 값
  onChange={(value) => setTime(value)}      // { hour: number; minute: number } 반환 (24시간 기준)
/>
```

### ✅ Swiper 기반 스와이프 동작

모바일 시간 선택 UI 특성상 스와이프와 함께 자연스럽게 스냅되는 동작이 필요했습니다. 터치 이벤트로 직접 구현할 경우 고려해야 할 요소가 많아 `Swiper`를 사용했습니다.

- `direction="vertical"` + `FreeMode` 모듈을 사용하여 세로 스와이프 제스처를 구현했습니다.
- `centeredSlides`로 선택된 슬라이드가 항상 가운데에 오도록 했습니다.
- `slideToClickedSlide`를 사용해 클릭으로도 값을 선택할 수 있도록 했습니다.

### ✅ 접근성 처리

`Swiper`는 headless UI 라이브러리가 아니기 때문에 필요한 접근성 속성은 별도로 구성했습니다.

- 컴포넌트 루트에는 `role="group"`과 `aria-label` 또는 `aria-labelledby`를 prop으로 받아 사용합니다. 두 속성을 모두 생략한 경우에는 기본값으로 `aria-label="시간 선택"`을 적용했습니다.
- 각 열(`role="listbox"`)은 `aria-label`을 직접 받아 접근 가능한 이름을 갖습니다. 처음에는 상위 래퍼에 `aria-label`을 지정하는 식으로 구현했지만, 해당 값이 내부 `listbox`까지 전달되지 않아 `TimePickerColumn`의 prop으로 분리했습니다.
- 각 슬라이드 항목은 `role="option"`과 `aria-selected` 속성을 사용했습니다.
- 선택된 슬라이드를 강조하는 배경 바는 시각적 요소이므로 `aria-hidden="true"`를 적용했습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

이후 캐러셀 컴포넌트를 구현할 때도 `Swiper`를 사용하면 될 것 같습니다~

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
