### PR TITLE
fix: 레이아웃 복구 및 접근성 위반, invalid HTML 속성 전달 수정

### DIFF
--- a/apps/web/src/shared/ui/BottomTab.tsx
+++ b/apps/web/src/shared/ui/BottomTab.tsx
@@ -28,6 +28,7 @@ export default function BottomTab() {
             key={id}
             render={<Link href={href} />}
             nativeButton={false}
+            role="link"
             icon={icon}
             label={label}
             active={pathname === href || pathname.startsWith(`${href}/`)}

--- a/packages/ui/src/components/AppBar/AppBar.stories.tsx
+++ b/packages/ui/src/components/AppBar/AppBar.stories.tsx
@@ -12,7 +12,7 @@ const meta: Meta<typeof AppBar> = {
     docs: {
       description: {
         component:
-          '앱 상단에 위치하는 내비게이션 바입니다. 액션 버튼은 `AppBar.Action`으로 추가합니다.\n\n페이지 이동이 목적인 `AppBar.Action`은 `render` prop에 라우터 링크 컴포넌트를 전달하고 `nativeButton={false}`를 함께 설정하세요. `<a>` 태그로 렌더링되어 스크린리더에서 링크로 인식되고, 새 탭에서 열기 등 브라우저 기본 동작도 지원됩니다.',
+          '앱 상단에 위치하는 내비게이션 바입니다. 액션 버튼은 `AppBar.Action`으로 추가합니다.\n\n페이지 이동이 목적인 `AppBar.Action`은 `render` prop에 라우터 링크 컴포넌트를 전달하고, `nativeButton={false}`와 `role="link"`를 함께 설정하세요. `<a>` 태그로 렌더링되어 스크린리더에서 링크로 인식되고, 새 탭에서 열기 등 브라우저 기본 동작도 지원됩니다.',
       },
     },
   },
@@ -32,6 +32,7 @@ const NAVIGATION_CODE = `\
       <AppBar.Action
         render={<Link href="/menu" />}
         nativeButton={false}
+        role="link"
         icon={<Icon />}
         aria-label="메뉴"
       />

--- a/packages/ui/src/components/AppBar/AppBar.tsx
+++ b/packages/ui/src/components/AppBar/AppBar.tsx
@@ -37,17 +37,19 @@ type AppBarActionProps = Omit<
 function Action({
   icon,
   className,
+  nativeButton,
   type = 'button',
   ...props
 }: AppBarActionProps) {
   return (
     <BaseButton
-      type={type}
+      {...props}
+      nativeButton={nativeButton}
       className={cn(
         'inline-flex cursor-pointer items-center justify-center rounded-md focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-semantic-stroke-subtle [&_svg]:size-7 [&_svg]:fill-semantic-object-bold',
         className,
       )}
-      {...props}
+      {...(nativeButton !== false && { type })}
     >
       {icon}
     </BaseButton>

--- a/packages/ui/src/components/AppBar/AppBar.tsx
+++ b/packages/ui/src/components/AppBar/AppBar.tsx
@@ -25,7 +25,7 @@ type AppBarProps = AppBarNavigationProps | AppBarBrandProps;
 
 type AppBarActionProps = Omit<
   ComponentPropsWithoutRef<typeof BaseButton>,
-  'className' | 'children'
+  'className' | 'children' | 'aria-label' | 'aria-labelledby'
 > & {
   icon: ReactNode;
   className?: string;

--- a/packages/ui/src/components/BottomNavigation/BottomNavigation.stories.tsx
+++ b/packages/ui/src/components/BottomNavigation/BottomNavigation.stories.tsx
@@ -23,7 +23,7 @@ const meta: Meta<typeof BottomNavigation> = {
     docs: {
       description: {
         component:
-          '앱 최상위 메뉴 간 이동을 담당하는 하단 내비게이션 바입니다. `BottomNavigation.Item`으로 탭을 구성할 수 있습니다.\n\n페이지 이동이 목적인 경우 `render` prop에 라우터 링크 컴포넌트를 전달하고 `nativeButton={false}`를 함께 설정하세요. `<a>` 태그로 렌더링되어 스크린리더에서 링크로 인식되고, 새 탭에서 열기 등 브라우저 기본 동작도 지원됩니다.',
+          '앱 최상위 메뉴 간 이동을 담당하는 하단 내비게이션 바입니다. `BottomNavigation.Item`으로 탭을 구성할 수 있습니다.\n\n페이지 이동이 목적인 경우 `render` prop에 라우터 링크 컴포넌트를 전달하고, `nativeButton={false}`와 `role="link"`를 함께 설정하세요. `<a>` 태그로 렌더링되어 스크린리더에서 링크로 인식되고, 새 탭에서 열기 등 브라우저 기본 동작도 지원됩니다.',
       },
       page: () => (
         <>
@@ -58,6 +58,7 @@ const TABS = [
       key={id}
       render={<Link href={href} />}
       nativeButton={false}
+      role="link"
       icon={icon}
       label={label}
       active={pathname === href || pathname.startsWith(\`\${href}/\`)}

--- a/packages/ui/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/packages/ui/src/components/BottomNavigation/BottomNavigation.tsx
@@ -19,18 +19,25 @@ type BottomNavigationProps = Omit<
   children: ReactNode;
 };
 
-function Item({ icon, label, active, ...props }: BottomNavigationItemProps) {
+function Item({
+  icon,
+  label,
+  active,
+  nativeButton,
+  ...props
+}: BottomNavigationItemProps) {
   return (
     <li>
       <BaseButton
         {...props}
+        nativeButton={nativeButton}
         className={cn(
           'flex cursor-pointer flex-col items-center justify-center gap-1',
           active
             ? '[&_svg]:fill-semantic-accent-normal'
             : '[&_svg]:fill-semantic-tab-disabled',
         )}
-        type="button"
+        {...(nativeButton !== false && { type: 'button' })}
         aria-current={active ? 'page' : undefined}
       >
         {icon}

--- a/packages/ui/src/components/DatePicker/DatePicker.tsx
+++ b/packages/ui/src/components/DatePicker/DatePicker.tsx
@@ -220,7 +220,13 @@ function DatePicker({ defaultValue, value, onChange }: DatePickerProps) {
             className="grid grid-cols-7"
           >
             {week.map((date) => (
-              <div key={date.toISOString()} role="gridcell">
+              <div
+                key={date.toISOString()}
+                role="gridcell"
+                aria-selected={
+                  selectedDate !== undefined && isSameDate(date, selectedDate)
+                }
+              >
                 <DatePickerCell
                   date={date}
                   isCurrentMonth={date.getMonth() === month}

--- a/packages/ui/src/components/DatePicker/DatePickerCell.tsx
+++ b/packages/ui/src/components/DatePicker/DatePickerCell.tsx
@@ -39,7 +39,6 @@ function DatePickerCell({
       onClick={onClick}
       disabled={isDisabled}
       tabIndex={isTabTarget ? 0 : -1}
-      aria-selected={isSelected}
       aria-label={`${date.getFullYear()}년 ${date.getMonth() + 1}월 ${date.getDate()}일${isToday ? ', 오늘' : ''}`}
       className={cn(
         'body-lg flex size-10 items-center justify-center rounded-lg transition-colors focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-semantic-accent-subtle',

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -7,17 +7,6 @@ import svgr from 'vite-plugin-svgr';
 
 const isStorybook = process.env.STORYBOOK === 'true';
 
-const externals = new Set([
-  'react',
-  'react-dom',
-  'react/jsx-runtime',
-  '@base-ui/react',
-  '@plog/utils',
-  'class-variance-authority',
-  'tailwindcss',
-  'use-sync-external-store',
-]);
-
 export default defineConfig({
   resolve: {
     alias: {
@@ -43,11 +32,17 @@ export default defineConfig({
     },
     rolldownOptions: {
       external: (id) => {
-        if (externals.has(id)) return true;
-        for (const ext of externals) {
-          if (id.startsWith(`${ext}/`)) return true;
-        }
-        return false;
+        const externals = [
+          'react',
+          'react-dom',
+          'react/jsx-runtime',
+          '@base-ui/react',
+          '@plog/utils',
+          'class-variance-authority',
+          'tailwindcss',
+          'use-sync-external-store',
+        ];
+        return externals.some((ext) => id === ext || id.startsWith(`${ext}/`));
       },
       output: {
         globals: {


### PR DESCRIPTION
## 📌 관련 이슈

- closes #56 

## 📝 작업 내용

- [x] `vite.config.ts` externals 배열 모듈 스코프 호이스팅 복구
- [x] `AppBar.Action` 타입 `Omit`에 `aria-label`, `aria-labelledby` 추가
- [x] `DatePickerCell`에서 `aria-selected` 제거
- [x] `DatePicker`의 `role="gridcell"` 래퍼에 `aria-selected` 적용
- [x] `BottomNavigation.Item` `nativeButton` 구조 분해, 조건부 `type` 적용
- [x] `AppBar.Action` `nativeButton` 구조 분해, 조건부 `type` 적용
- [x] `BottomTab` 링크 렌더링에 `role="link"` 추가
- [x] `BottomNavigation`, `AppBar` 링크 사용 예시 업데이트

## 🔎 자세한 설명

### ✅ `vite.config.ts` externals 호이스팅 복구

externals를 모듈 스코프의 `Set`으로 호이스팅한 이후 레이아웃이 깨지는 문제가 있었습니다. 정확한 원인 파악이 어려워 우선 기존 방식(함수 내부 배열)으로 되돌렸습니다.

### ✅ `AppBar.Action` 타입 `Omit`에 `aria-label` / `aria-labelledby` 추가

`ComponentPropsWithoutRef<typeof BaseButton>`에는 `aria-label?: string | undefined`가 포함되어 있습니다. `IconButton`과 동일한 방식으로 `aria-label`, `aria-labelledby`를 명시적으로 제외해 타입을 정리했습니다.

### ✅ `DatePicker` WAI-ARIA 패턴 준수

WAI-ARIA 명세상 `aria-selected`는 `role="button"`에 적용할 수 없습니다. `aria-selected`를 `button`에서 제거하고 상위 `role="gridcell"` 요소로 이동했습니다.

### ✅ `nativeButton={false}`일 때 `type` 속성 제거

base-ui `Button`은 `nativeButton={false}`일 경우 `render`로 전달된 요소를 그대로 사용합니다. 이때 `type="button"`이 전달되면 `<a type="button">`처럼 잘못된 마크업이 생성됩니다. `nativeButton !== false`일 때만 `type`을 전달하도록 분기 처리했습니다.

### ✅ 링크 렌더링 시 `role="link"`로 보정

base-ui `Button`은 `nativeButton={false}`에서도 기본적으로 `role="button"`을 부여합니다. 이 상태에서 `<a>`가 페이지 이동 용도로 사용되면, 스크린리더는 버튼으로 인식해 실제 동작과 어긋나므로 `role="link"`를 명시적으로 지정했습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

PR #55 리뷰 피드백 반영 커밋입니다~ 접근성 수정 위주라 레이아웃 복구 외에 시각적 변화는 없습니다!

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
