### PR TITLE
feat: 공통 캐러셀 컴포넌트 구현

### DIFF
--- a/packages/ui/src/components/Carousel/Carousel.stories.tsx
+++ b/packages/ui/src/components/Carousel/Carousel.stories.tsx
@@ -1,0 +1,193 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import Carousel from './Carousel';
+
+const meta: Meta<typeof Carousel> = {
+  title: 'Components/Carousel',
+  component: Carousel,
+  tags: ['autodocs'],
+  parameters: {
+    layout: 'centered',
+    docs: {
+      description: {
+        component:
+          '스와이프로 슬라이드를 전환할 수 있는 컴포넌트입니다. `Carousel.Slide`로 각 슬라이드를 구성합니다.',
+      },
+    },
+  },
+  argTypes: {
+    loop: {
+      description: '마지막 슬라이드에서 첫 번째 슬라이드로 순환합니다.',
+      control: 'boolean',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'false' },
+      },
+    },
+    initialSlide: {
+      description: '초기 슬라이드 인덱스입니다.',
+      control: 'number',
+      table: {
+        type: { summary: 'number' },
+        defaultValue: { summary: '0' },
+      },
+    },
+    onChange: {
+      description: '슬라이드 전환 시 현재 인덱스를 반환합니다.',
+      table: { type: { summary: '(index: number) => void' } },
+    },
+    'aria-label': {
+      description:
+        '캐러셀 영역의 접근 가능한 이름입니다. `aria-labelledby`와 둘 중 하나를 반드시 전달해야 합니다.',
+      control: 'text',
+    },
+    children: { table: { disable: true } },
+    className: { table: { disable: true } },
+    'aria-labelledby': { table: { disable: true } },
+  },
+  args: {
+    'aria-label': '게시물 이미지',
+  },
+  decorators: [
+    (Story) => (
+      <div className="max-w-120">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Carousel>;
+
+const IMAGES = [
+  'https://images.unsplash.com/photo-1501854140801-50d01698950b?w=800&h=800&fit=crop',
+  'https://images.unsplash.com/photo-1464822759023-fed622ff2c3b?w=800&h=800&fit=crop',
+  'https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=800&h=800&fit=crop',
+];
+
+const DEFAULT_CODE = `\
+<Carousel aria-label="게시물 이미지">
+  <Carousel.Slide>
+    <img src="..." alt="" />
+  </Carousel.Slide>
+  <Carousel.Slide>
+    <img src="..." alt="" />
+  </Carousel.Slide>
+  <Carousel.Slide>
+    <img src="..." alt="" />
+  </Carousel.Slide>
+</Carousel>`;
+
+const LOOP_CODE = `\
+<Carousel aria-label="게시물 이미지" loop>
+  <Carousel.Slide>
+    <img src="..." alt="" />
+  </Carousel.Slide>
+  <Carousel.Slide>
+    <img src="..." alt="" />
+  </Carousel.Slide>
+  <Carousel.Slide>
+    <img src="..." alt="" />
+  </Carousel.Slide>
+</Carousel>`;
+
+const SINGLE_SLIDE_CODE = `\
+<Carousel aria-label="게시물 이미지">
+  <Carousel.Slide>
+    <img src="..." alt="" />
+  </Carousel.Slide>
+</Carousel>`;
+
+const INITIAL_SLIDE_CODE = `\
+<Carousel aria-label="게시물 이미지" initialSlide={2}>
+  <Carousel.Slide>
+    <img src="..." alt="" />
+  </Carousel.Slide>
+  <Carousel.Slide>
+    <img src="..." alt="" />
+  </Carousel.Slide>
+  <Carousel.Slide>
+    <img src="..." alt="" />
+  </Carousel.Slide>
+</Carousel>`;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      source: { code: DEFAULT_CODE },
+    },
+  },
+  render: (args) => (
+    <Carousel {...args}>
+      {IMAGES.map((src, i) => (
+        <Carousel.Slide key={i}>
+          <img src={src} alt="" />
+        </Carousel.Slide>
+      ))}
+    </Carousel>
+  ),
+};
+
+export const Loop: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`loop`를 설정하면 마지막 슬라이드에서 첫 번째 슬라이드로 순환합니다.',
+      },
+      source: { code: LOOP_CODE },
+    },
+  },
+  args: { loop: true },
+  render: (args) => (
+    <Carousel {...args}>
+      {IMAGES.map((src, i) => (
+        <Carousel.Slide key={i}>
+          <img src={src} alt="" />
+        </Carousel.Slide>
+      ))}
+    </Carousel>
+  ),
+};
+
+export const SingleSlide: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '슬라이드가 1개인 경우 페이지네이션과 스와이프가 자동으로 비활성화됩니다.',
+      },
+      source: { code: SINGLE_SLIDE_CODE },
+    },
+  },
+  render: (args) => (
+    <Carousel {...args}>
+      <Carousel.Slide>
+        <img src={IMAGES[0]} alt="" />
+      </Carousel.Slide>
+    </Carousel>
+  ),
+};
+
+export const InitialSlide: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`initialSlide`로 초기에 표시할 슬라이드 인덱스를 지정할 수 있습니다.',
+      },
+      source: { code: INITIAL_SLIDE_CODE },
+    },
+  },
+  args: { initialSlide: 2 },
+  render: (args) => (
+    <Carousel {...args}>
+      {IMAGES.map((src, i) => (
+        <Carousel.Slide key={i}>
+          <img src={src} alt="" />
+        </Carousel.Slide>
+      ))}
+    </Carousel>
+  ),
+};

--- a/packages/ui/src/components/Carousel/Carousel.tsx
+++ b/packages/ui/src/components/Carousel/Carousel.tsx
@@ -42,7 +42,7 @@ function CarouselRoot({
       role="region"
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledBy}
-      aria-roledescription="carousel"
+      aria-roledescription="캐러셀"
       className={cn(
         'relative w-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-semantic-accent-alternative',
         '[--swiper-pagination-bottom:12px] [--swiper-pagination-bullet-horizontal-gap:6px] [--swiper-pagination-color:white]',
@@ -64,7 +64,7 @@ function CarouselRoot({
         modules={[A11y, Keyboard, Pagination]}
         a11y={{
           enabled: true,
-          itemRoleDescriptionMessage: 'slide',
+          itemRoleDescriptionMessage: '슬라이드',
           slideLabelMessage: '슬라이드 {{index}} / {{slidesLength}}',
         }}
         keyboard={{ enabled: false }}

--- a/packages/ui/src/components/Carousel/Carousel.tsx
+++ b/packages/ui/src/components/Carousel/Carousel.tsx
@@ -4,7 +4,7 @@ import 'swiper/css/pagination';
 import { Children, type ReactNode, useRef } from 'react';
 
 import { cn } from '@plog/utils';
-import { Keyboard, Pagination } from 'swiper/modules';
+import { A11y, Keyboard, Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 import type { Swiper as SwiperType } from 'swiper/types';
 
@@ -39,10 +39,6 @@ function CarouselRoot({
 
   return (
     <div
-      role="region"
-      aria-roledescription="carousel"
-      aria-label={ariaLabel}
-      aria-labelledby={ariaLabelledBy}
       className={cn(
         'relative w-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-semantic-accent-alternative',
         '[--swiper-pagination-bottom:12px] [--swiper-pagination-bullet-horizontal-gap:6px] [--swiper-pagination-color:white]',
@@ -51,6 +47,7 @@ function CarouselRoot({
         !isSingle && 'cursor-grab active:cursor-grabbing',
         className,
       )}
+      aria-controls="carousel-swiper"
       tabIndex={0}
       onFocus={() => {
         swiperRef.current?.keyboard.enable();
@@ -60,7 +57,17 @@ function CarouselRoot({
       }}
     >
       <Swiper
-        modules={[Keyboard, Pagination]}
+        className="w-full"
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledBy}
+        modules={[A11y, Keyboard, Pagination]}
+        a11y={{
+          enabled: true,
+          containerRole: 'region',
+          containerRoleDescriptionMessage: 'carousel',
+          itemRoleDescriptionMessage: 'slide',
+          slideLabelMessage: '슬라이드 {{index}} / {{slidesLength}}',
+        }}
         keyboard={{ enabled: false }}
         pagination={isSingle ? false : { clickable: false }}
         allowTouchMove={!isSingle}
@@ -70,7 +77,6 @@ function CarouselRoot({
         onSwiper={(swiper) => {
           swiperRef.current = swiper;
         }}
-        className="w-full"
       >
         {children}
       </Swiper>
@@ -81,8 +87,6 @@ function CarouselRoot({
 function Slide({ children, className }: CarouselSlideProps) {
   return (
     <SwiperSlide
-      role="group"
-      aria-roledescription="slide"
       className={cn(
         'relative aspect-square [&_img]:h-full [&_img]:w-full [&_img]:object-cover [&_img]:drag-none',
         className,

--- a/packages/ui/src/components/Carousel/Carousel.tsx
+++ b/packages/ui/src/components/Carousel/Carousel.tsx
@@ -71,7 +71,7 @@ function CarouselRoot({
         keyboard={{ enabled: false }}
         pagination={isSingle ? false : { clickable: false }}
         allowTouchMove={!isSingle}
-        loop={loop}
+        loop={!isSingle && loop}
         initialSlide={initialSlide}
         onSlideChange={(swiper) => onChange?.(swiper.realIndex)}
         onSwiper={(swiper) => {

--- a/packages/ui/src/components/Carousel/Carousel.tsx
+++ b/packages/ui/src/components/Carousel/Carousel.tsx
@@ -47,7 +47,6 @@ function CarouselRoot({
         !isSingle && 'cursor-grab active:cursor-grabbing',
         className,
       )}
-      aria-controls="carousel-swiper"
       tabIndex={0}
       onFocus={() => {
         swiperRef.current?.keyboard.enable();

--- a/packages/ui/src/components/Carousel/Carousel.tsx
+++ b/packages/ui/src/components/Carousel/Carousel.tsx
@@ -1,0 +1,86 @@
+import 'swiper/css';
+import 'swiper/css/pagination';
+
+import { Children, type ReactNode } from 'react';
+
+import { cn } from '@plog/utils';
+import { Pagination } from 'swiper/modules';
+import { Swiper, SwiperSlide } from 'swiper/react';
+
+type CarouselProps = {
+  loop?: boolean;
+  initialSlide?: number;
+  onChange?: (index: number) => void;
+  className?: string;
+  children: ReactNode;
+} & (
+  | { 'aria-label': string; 'aria-labelledby'?: never }
+  | { 'aria-label'?: never; 'aria-labelledby': string }
+);
+
+type CarouselSlideProps = {
+  children: ReactNode;
+  className?: string;
+};
+
+function CarouselRoot({
+  loop = false,
+  initialSlide = 0,
+  onChange,
+  className,
+  children,
+  'aria-label': ariaLabel,
+  'aria-labelledby': ariaLabelledBy,
+}: CarouselProps) {
+  const isSingle = Children.count(children) <= 1;
+
+  return (
+    <div
+      role="region"
+      aria-roledescription="carousel"
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      className={cn(
+        'relative w-full',
+        '[--swiper-pagination-bottom:12px] [--swiper-pagination-bullet-horizontal-gap:6px] [--swiper-pagination-color:white]',
+        '[--swiper-pagination-bullet-inactive-color:white] [--swiper-pagination-bullet-inactive-opacity:0.6]',
+        '[&_.swiper-pagination-bullet]:!size-1.5 [&_.swiper-pagination-bullet]:align-middle [&_.swiper-pagination-bullet-active]:!size-2',
+        !isSingle && 'cursor-grab active:cursor-grabbing',
+        className,
+      )}
+    >
+      <Swiper
+        modules={[Pagination]}
+        pagination={isSingle ? false : { clickable: false }}
+        allowTouchMove={!isSingle}
+        loop={loop}
+        initialSlide={initialSlide}
+        onSlideChange={(swiper) => onChange?.(swiper.realIndex)}
+        className="w-full"
+      >
+        {children}
+      </Swiper>
+    </div>
+  );
+}
+
+function Slide({ children, className }: CarouselSlideProps) {
+  return (
+    <SwiperSlide
+      role="group"
+      aria-roledescription="slide"
+      className={cn(
+        'relative aspect-square [&_img]:h-full [&_img]:w-full [&_img]:object-cover [&_img]:drag-none',
+        className,
+      )}
+    >
+      <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0)_72.08%,rgba(0,0,0,0.5)_100%)]" />
+      {children}
+    </SwiperSlide>
+  );
+}
+Slide.displayName = 'SwiperSlide';
+
+const Carousel = Object.assign(CarouselRoot, { Slide });
+
+export default Carousel;

--- a/packages/ui/src/components/Carousel/Carousel.tsx
+++ b/packages/ui/src/components/Carousel/Carousel.tsx
@@ -77,7 +77,9 @@ function CarouselRoot({
           swiperRef.current = swiper;
         }}
       >
-        {children}
+        {Children.map(children, (child) => (
+          <SwiperSlide>{child}</SwiperSlide>
+        ))}
       </Swiper>
     </div>
   );
@@ -85,7 +87,7 @@ function CarouselRoot({
 
 function Slide({ children, className }: CarouselSlideProps) {
   return (
-    <SwiperSlide
+    <div
       className={cn(
         'relative aspect-square [&_img]:h-full [&_img]:w-full [&_img]:object-cover [&_img]:drag-none',
         className,
@@ -93,10 +95,9 @@ function Slide({ children, className }: CarouselSlideProps) {
     >
       <div className="pointer-events-none absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0)_72.08%,rgba(0,0,0,0.5)_100%)]" />
       {children}
-    </SwiperSlide>
+    </div>
   );
 }
-Slide.displayName = 'SwiperSlide';
 
 const Carousel = Object.assign(CarouselRoot, { Slide });
 

--- a/packages/ui/src/components/Carousel/Carousel.tsx
+++ b/packages/ui/src/components/Carousel/Carousel.tsx
@@ -1,11 +1,12 @@
 import 'swiper/css';
 import 'swiper/css/pagination';
 
-import { Children, type ReactNode } from 'react';
+import { Children, type ReactNode, useRef } from 'react';
 
 import { cn } from '@plog/utils';
-import { Pagination } from 'swiper/modules';
+import { Keyboard, Pagination } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
+import type { Swiper as SwiperType } from 'swiper/types';
 
 type CarouselProps = {
   loop?: boolean;
@@ -32,6 +33,8 @@ function CarouselRoot({
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledBy,
 }: CarouselProps) {
+  const swiperRef = useRef<SwiperType | null>(null);
+
   const isSingle = Children.count(children) <= 1;
 
   return (
@@ -41,21 +44,32 @@ function CarouselRoot({
       aria-label={ariaLabel}
       aria-labelledby={ariaLabelledBy}
       className={cn(
-        'relative w-full',
+        'relative w-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-semantic-accent-alternative',
         '[--swiper-pagination-bottom:12px] [--swiper-pagination-bullet-horizontal-gap:6px] [--swiper-pagination-color:white]',
         '[--swiper-pagination-bullet-inactive-color:white] [--swiper-pagination-bullet-inactive-opacity:0.6]',
         '[&_.swiper-pagination-bullet]:!size-1.5 [&_.swiper-pagination-bullet]:align-middle [&_.swiper-pagination-bullet-active]:!size-2',
         !isSingle && 'cursor-grab active:cursor-grabbing',
         className,
       )}
+      tabIndex={0}
+      onFocus={() => {
+        swiperRef.current?.keyboard.enable();
+      }}
+      onBlur={() => {
+        swiperRef.current?.keyboard.disable();
+      }}
     >
       <Swiper
-        modules={[Pagination]}
+        modules={[Keyboard, Pagination]}
+        keyboard={{ enabled: false }}
         pagination={isSingle ? false : { clickable: false }}
         allowTouchMove={!isSingle}
         loop={loop}
         initialSlide={initialSlide}
         onSlideChange={(swiper) => onChange?.(swiper.realIndex)}
+        onSwiper={(swiper) => {
+          swiperRef.current = swiper;
+        }}
         className="w-full"
       >
         {children}

--- a/packages/ui/src/components/Carousel/Carousel.tsx
+++ b/packages/ui/src/components/Carousel/Carousel.tsx
@@ -39,6 +39,10 @@ function CarouselRoot({
 
   return (
     <div
+      role="region"
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledBy}
+      aria-roledescription="carousel"
       className={cn(
         'relative w-full focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-semantic-accent-alternative',
         '[--swiper-pagination-bottom:12px] [--swiper-pagination-bullet-horizontal-gap:6px] [--swiper-pagination-color:white]',
@@ -57,13 +61,9 @@ function CarouselRoot({
     >
       <Swiper
         className="w-full"
-        aria-label={ariaLabel}
-        aria-labelledby={ariaLabelledBy}
         modules={[A11y, Keyboard, Pagination]}
         a11y={{
           enabled: true,
-          containerRole: 'region',
-          containerRoleDescriptionMessage: 'carousel',
           itemRoleDescriptionMessage: 'slide',
           slideLabelMessage: '슬라이드 {{index}} / {{slidesLength}}',
         }}

--- a/packages/ui/src/components/Carousel/index.ts
+++ b/packages/ui/src/components/Carousel/index.ts
@@ -1,0 +1,1 @@
+export { default as Carousel } from './Carousel';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -4,6 +4,7 @@ export * from './components/Badge';
 export * from './components/BottomNavigation';
 export * from './components/BottomSheet';
 export * from './components/Button';
+export * from './components/Carousel';
 export * from './components/Checkbox';
 export * from './components/Chip';
 export * from './components/DatePicker';

--- a/packages/ui/src/styles/index.css
+++ b/packages/ui/src/styles/index.css
@@ -1,5 +1,6 @@
-@import "./animations.css";
-@import "./color-primitive.css";
-@import "./color-semantic.css";
-@import "./typography-primitive.css";
-@import "./typography-semantic.css";
+@import './animations.css';
+@import './color-primitive.css';
+@import './color-semantic.css';
+@import './typography-primitive.css';
+@import './typography-semantic.css';
+@import './utilities.css';

--- a/packages/ui/src/styles/utilities.css
+++ b/packages/ui/src/styles/utilities.css
@@ -1,0 +1,4 @@
+@utility drag-none {
+  -webkit-user-drag: none;
+  user-select: none;
+}

--- a/packages/ui/src/vite-env.d.ts
+++ b/packages/ui/src/vite-env.d.ts
@@ -1,2 +1,5 @@
 /// <reference types="vite/client" />
 /// <reference types="vite-plugin-svgr/client" />
+
+declare module 'swiper/css' {}
+declare module 'swiper/css/pagination' {}


### PR DESCRIPTION
## 📌 관련 이슈

- closes #62 

## 📝 작업 내용

- [x] `Carousel` 공통 컴포넌트 구현
- [x] Storybook 스토리 및 autodocs 문서 작성

## 🔎 자세한 설명

### ✅ 컴포넌트 구조

```tsx
<Carousel aria-label="게시물 이미지">
  <Carousel.Slide>
    <img src="..." alt="" />
  </Carousel.Slide>
  <Carousel.Slide>
    <img src="..." alt="" />
  </Carousel.Slide>
</Carousel>
```

- ~~`Carousel.Slide`는 내부적으로 `SwiperSlide`를 감싸고 있으며,`Swiper`가 자식 슬라이드를 인식할 수 있도록 `Slide.displayName`을 `'SwiperSlide'`로 설정했습니다.~~
  - → `CarouselRoot`에서 `Children.map`으로 각 슬라이드를 `SwiperSlide`로 감싸도록 수정했습니다. (6b9a033)
- `Children.count`로 슬라이드 수를 감지하여 슬라이드가 1개인 경우 페이지네이션을 숨기고 스와이프가 비활성화 되도록 했습니다.

### ✅ 접근성 처리

- 컨테이너에 `role="region"` + `aria-roledescription="carousel"` + `aria-label` (또는 `aria-labelledby`)를 적용했습니다.
- 각 슬라이드에 `aria-roledescription="slide"` + 슬라이드 위치 레이블을 적용했습니다.

### ✅ 키보드 컨트롤

- `Swiper`의 `keyboard.onlyInViewport` 옵션은 뷰포트 내 모든 Swiper 인스턴스에 키보드 입력을 동시에 적용하기 때문에, 피드처럼 여러 캐러셀이 동시에 노출되는 환경에서는 모든 캐러셀에 동일한 키보드 조작이 전달되는 문제가 있습니다.
- 이를 해결하기 위해 Swiper를 `tabIndex={0}`가 설정된 `div`로 감싸고, `keyboard: { enabled: false }`로 초기화한 뒤 `swiperRef`를 통해 포커스 상태에 따라 키보드 컨트롤을 직접 활성화/비활성화합니다.
- 포커스가 이동하면 이전 캐러셀의 키보드 제어가 해제되어 한 번에 하나의 캐러셀만 키보드로 조작되도록 했습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
