### PR TITLE
feat: TimePicker 분 단위 지정 기능 추가

### DIFF
--- a/packages/ui/src/components/TimePicker/TimePicker.stories.tsx
+++ b/packages/ui/src/components/TimePicker/TimePicker.stories.tsx
@@ -25,6 +25,14 @@ const meta: Meta<typeof TimePicker> = {
         type: { summary: '{ hour: number; minute: number }' },
       },
     },
+    minuteStep: {
+      description: '분 선택 단위를 지정합니다.',
+      control: { type: 'number', min: 1, max: 30 },
+      table: {
+        type: { summary: 'number' },
+        defaultValue: { summary: '1' },
+      },
+    },
     value: { table: { disable: true } },
     onChange: { table: { disable: true } },
   },
@@ -45,6 +53,20 @@ export const WithDefaultValue: Story = {
   },
   args: {
     defaultValue: { hour: 14, minute: 30 },
+  },
+};
+
+export const WithMinuteStep: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story: '`minuteStep`으로 분 선택 단위를 지정할 수 있습니다.',
+      },
+    },
+  },
+  args: {
+    minuteStep: 10,
+    defaultValue: { hour: 9, minute: 0 },
   },
 };
 

--- a/packages/ui/src/components/TimePicker/TimePicker.tsx
+++ b/packages/ui/src/components/TimePicker/TimePicker.tsx
@@ -18,6 +18,9 @@ const HOURS = Array.from({ length: 12 }, (_, i) =>
 );
 
 function buildMinutes(step: number) {
+  if (!Number.isInteger(step) || step < 1) {
+    throw new Error(`minuteStep must be a positive integer, got ${step}`);
+  }
   const minutes: string[] = [];
   for (let m = 0; m < 60; m += step) {
     minutes.push(String(m).padStart(2, '0'));

--- a/packages/ui/src/components/TimePicker/TimePicker.tsx
+++ b/packages/ui/src/components/TimePicker/TimePicker.tsx
@@ -7,6 +7,7 @@ type TimePickerProps = {
   defaultValue?: TimeValue;
   value?: TimeValue;
   onChange?: (value: TimeValue) => void;
+  minuteStep?: number;
 } & (
   | { 'aria-label'?: string; 'aria-labelledby'?: never }
   | { 'aria-label'?: never; 'aria-labelledby'?: string }
@@ -15,9 +16,14 @@ type TimePickerProps = {
 const HOURS = Array.from({ length: 12 }, (_, i) =>
   String(i + 1).padStart(2, '0'),
 );
-const MINUTES = Array.from({ length: 60 }, (_, i) =>
-  String(i).padStart(2, '0'),
-);
+
+function buildMinutes(step: number) {
+  const minutes: string[] = [];
+  for (let m = 0; m < 60; m += step) {
+    minutes.push(String(m).padStart(2, '0'));
+  }
+  return minutes;
+}
 
 function hourToIndex(hour24: number): number {
   const h12 = hour24 % 12;
@@ -34,6 +40,7 @@ function TimePicker({
   defaultValue,
   value,
   onChange,
+  minuteStep = 1,
   'aria-label': ariaLabel,
   'aria-labelledby': ariaLabelledBy,
 }: TimePickerProps) {
@@ -49,6 +56,12 @@ function TimePicker({
     if (!isControlled) setInternalValue(next);
     onChange?.(next);
   };
+
+  const MINUTES = buildMinutes(minuteStep);
+  const minuteIndex = Math.min(
+    Math.round(current.minute / minuteStep),
+    MINUTES.length - 1,
+  );
 
   const meridiemIndex = current.hour < 12 ? 0 : 1;
   const effectiveAriaLabel = ariaLabelledBy
@@ -84,8 +97,9 @@ function TimePicker({
       <TimePickerColumn
         aria-label="분"
         items={MINUTES}
-        selectedIndex={current.minute}
-        onChange={(i) => update({ minute: i })}
+        selectedIndex={minuteIndex}
+        onChange={(i) => update({ minute: i * minuteStep })}
+        loop={MINUTES.length > 3}
       />
     </div>
   );

--- a/packages/ui/src/components/TimePicker/TimePickerColumn.tsx
+++ b/packages/ui/src/components/TimePicker/TimePickerColumn.tsx
@@ -1,3 +1,5 @@
+import 'swiper/css';
+
 import { useEffect, useRef } from 'react';
 
 import { cn } from '@plog/utils';
@@ -61,7 +63,7 @@ function TimePickerColumn({
         {items.map((item) => (
           <SwiperSlide
             key={item}
-            className="flex w-14 cursor-pointer items-center justify-center select-none"
+            className="flex! w-14! cursor-pointer items-center justify-center select-none"
           >
             {({ isActive }) => (
               <span


### PR DESCRIPTION
## 📌 관련 이슈

- closes #73 

## 📝 작업 내용

- [x] `swiper/css` 전역 스타일로 인한 `TimePickerColumn` 스타일링 오류 수정
- [x] `TimePicker`에 `minuteStep` prop 추가
- [x] `TimePicker` Storybook 문서 업데이트

## 🔎 자세한 설명

### ✅ `swiper/css` 전역 스타일 충돌 수정

Swiper 기본 스타일이 `TimePickerColumn` 클래스에 영향을 주는 문제가 있어 충돌되는 스타일에 Tailwind의 `!`(important) 접미사를 추가했습니다.

### ✅ 분 선택 단위 지정 기능 추가

`minuteStep` prop(기본값 `1`)을 추가하여 `buildMinutes(step)`를 통해 지정된 단위의 분 목록을 생성하도록 변경했고, `MINUTES.length > 3`일 때만 loop를 활성화하도록 수정했습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
