### PR TITLE
hotfix: zustand combine 미들웨어 import 경로 수정

### DIFF
--- a/apps/web/src/shared/lib/dialog/use-dialog-store.ts
+++ b/apps/web/src/shared/lib/dialog/use-dialog-store.ts
@@ -1,7 +1,7 @@
 import { type ReactNode } from 'react';
 
 import { create } from 'zustand';
-import { combine } from 'zustand/middleware/combine';
+import { combine } from 'zustand/middleware';
 
 export type DialogType = 'alert' | 'confirm';
 


### PR DESCRIPTION
## 📌 관련 이슈

- closes #77 

## 📝 작업 내용

- [x] zustand combine 미들웨어 import 경로 수정

## 🔎 자세한 설명

`zustand/middleware/combine`은 타입 정의(.d.ts)만 있고 .js가 없어서 번들러가 해석을 못하는 문제가 있어 import 경로를 수정했습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

@coderabbitai ignore

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.