### PR TITLE
chore: simple-import-sort 규칙을 전체 파일 범위로 분리

### DIFF
--- a/apps/web/app/(with-tab)/feed/layout.tsx
+++ b/apps/web/app/(with-tab)/feed/layout.tsx
@@ -2,8 +2,9 @@
 
 import { ReactNode } from 'react';
 
-import { AppBar } from '@plog/ui';
 import { usePathname, useRouter } from 'next/navigation';
+
+import { AppBar } from '@plog/ui';
 
 type FeedLayoutProps = {
   children: ReactNode;

--- a/apps/web/app/(with-tab)/log/layout.tsx
+++ b/apps/web/app/(with-tab)/log/layout.tsx
@@ -2,8 +2,9 @@
 
 import { ReactNode } from 'react';
 
-import { AppBar } from '@plog/ui';
 import { usePathname, useRouter } from 'next/navigation';
+
+import { AppBar } from '@plog/ui';
 
 export default function CreateFeedLayout({
   children,

--- a/apps/web/app/signup/page.tsx
+++ b/apps/web/app/signup/page.tsx
@@ -1,5 +1,6 @@
-import { getDefaultImages } from '@/entities/user/api/server';
 import { SignupPage } from '@/views/signup';
+
+import { getDefaultImages } from '@/entities/user/api/server';
 
 export default async function Page() {
   const defaultImages = await getDefaultImages();

--- a/apps/web/app/terms/geolocation/page.tsx
+++ b/apps/web/app/terms/geolocation/page.tsx
@@ -1,5 +1,6 @@
-import { getSanitizedTerm } from '@/entities/user/api/server';
 import { TermsPage } from '@/views/terms';
+
+import { getSanitizedTerm } from '@/entities/user/api/server';
 
 export const dynamic = 'force-static';
 export const metadata = { title: '위치정보 이용약관' };

--- a/apps/web/app/terms/privacy/page.tsx
+++ b/apps/web/app/terms/privacy/page.tsx
@@ -1,5 +1,6 @@
-import { getSanitizedTerm } from '@/entities/user/api/server';
 import { TermsPage } from '@/views/terms';
+
+import { getSanitizedTerm } from '@/entities/user/api/server';
 
 export const dynamic = 'force-static';
 export const metadata = { title: '개인정보 처리방침' };

--- a/apps/web/app/terms/service/page.tsx
+++ b/apps/web/app/terms/service/page.tsx
@@ -1,5 +1,6 @@
-import { getSanitizedTerm } from '@/entities/user/api/server';
 import { TermsPage } from '@/views/terms';
+
+import { getSanitizedTerm } from '@/entities/user/api/server';
 
 export const dynamic = 'force-static';
 export const metadata = { title: '서비스 이용약관' };

--- a/apps/web/eslint.config.mjs
+++ b/apps/web/eslint.config.mjs
@@ -20,6 +20,24 @@ const config = [
     ...nextVitals,
     ...nextTs,
     {
+      files: ['**/*.{ts,tsx}'],
+      rules: {
+        'simple-import-sort/imports': [
+          'error',
+          {
+            groups: [
+              ['^\\u0000'],
+              ['^react'],
+              ['^next'],
+              ['^@?\\w'],
+              ...FSD_LAYERS.map(({ type }) => [`^@/${type}`]),
+              ['^\\.'],
+            ],
+          },
+        ],
+      },
+    },
+    {
       files: ['src/**/*.{ts,tsx}'],
       plugins: { boundaries },
       settings: {
@@ -43,19 +61,6 @@ const config = [
                 type === 'shared' || type === 'app' ? index : index + 1,
               ).map((l) => l.type),
             })),
-          },
-        ],
-        'simple-import-sort/imports': [
-          'error',
-          {
-            groups: [
-              ['^\\u0000'],
-              ['^react'],
-              ['^next'],
-              ['^@?\\w'],
-              ...FSD_LAYERS.map(({ type }) => [`^@/${type}`]),
-              ['^\\.'],
-            ],
           },
         ],
       },


### PR DESCRIPTION
## 📌 관련 이슈

- closes #90 

## 📝 작업 내용

- [x] `simple-import-sort/imports` 규칙을 `boundaries` 플러그인 블록(`src/**`)에서 분리해 별도 블록으로 이동

## 🔎 자세한 설명

## 🖼️ 스크린샷

## 💬 리뷰어에게

@coderabbitai ignore

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
