### PR TITLE
fix: 카카오맵 초기화 콜백 실행 시점 수정

### DIFF
--- a/apps/web/src/views/map/ui/MapPage.tsx
+++ b/apps/web/src/views/map/ui/MapPage.tsx
@@ -92,7 +92,7 @@ export default function MapPage() {
       <Script
         src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&libraries=clusterer&autoload=false`}
         strategy="afterInteractive"
-        onLoad={handleLoad}
+        onReady={handleLoad}
       />
       <div className="relative z-0 h-[calc(100dvh-var(--spacing-bottom-tab))] w-full max-w-layout">
         <div ref={containerRef} className="absolute inset-0" />


### PR DESCRIPTION
## 📌 관련 이슈

- closes #96 

## 📝 작업 내용

- [x] 카카오맵 초기화 콜백 실행 시점 수정

## 🔎 자세한 설명

Next.js `<Script>` 컴포넌트의 `onLoad`는 스크립트가 최초 로드될 때 한 번만 실행되는데, 탭 전환으로 지도 페이지가 언마운트 후 다시 마운트되더라도, 카카오 SDK는 이미 로드된 상태이므로 `onLoad`가 다시 호출되지 않아 지도가 초기화되지 않았습니다.

`onLoad`를 `onReady`로 교체하여 컴포넌트가 마운트될 때마다 지도를 초기화하도록 수정했습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

현재 `(with-tab)` 외부 페이지(404 등)에서 `router.back()`으로 `(with-tab)` 내부 페이지로 복귀할 때 React lifecycle 전체가 실행되지 않는 문제가 있습니다.

`template.tsx`, `force-dynamic` 적용 및 `pageshow`, `popstate` 등 이벤트 핸들러 기반 처리도 해보았는데 모두 동일하게 동작했습니다. 관련 내용은 추후 별도 이슈로 추적하겠습니다~

@coderabbitai ignore

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
