### PR TITLE
feat: 마이페이지 내 기록 및 북마크 탭 구현

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -7,6 +7,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'images.unsplash.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'storage.googleapis.com',
+      },
     ],
   },
   turbopack: {

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -10,6 +10,7 @@ const nextConfig: NextConfig = {
       {
         protocol: 'https',
         hostname: 'storage.googleapis.com',
+        pathname: '/plog-imgstorage-bucket/**',
       },
     ],
   },

--- a/apps/web/src/entities/feed/index.ts
+++ b/apps/web/src/entities/feed/index.ts
@@ -17,7 +17,12 @@ export {
   WorkConvenience,
 } from './model/place-tag';
 export { FEED_QUERY_KEY } from './model/query-keys';
-export type { FeedPage, FeedPost } from './model/types';
+export type {
+  BookmarkSortType,
+  FeedPage,
+  FeedPost,
+  PostSortType,
+} from './model/types';
 export { default as FeedGridItem } from './ui/FeedGridItem';
 export { default as FeedListItem } from './ui/FeedListItem';
 export { default as FeedStatsSummary } from './ui/FeedStatsSummary';

--- a/apps/web/src/entities/feed/model/types.ts
+++ b/apps/web/src/entities/feed/model/types.ts
@@ -16,9 +16,13 @@ export type FeedPost = {
   like: boolean;
   bookMark: boolean;
   placeCategory?: string;
+  isPublic?: boolean;
 };
 
 export type FeedPage = {
   items: FeedPost[];
   nextPage: number | undefined;
 };
+
+export type PostSortType = 'latest' | 'focus' | 'studyTime';
+export type BookmarkSortType = 'latest' | 'likes';

--- a/apps/web/src/entities/feed/ui/FeedGridItem.tsx
+++ b/apps/web/src/entities/feed/ui/FeedGridItem.tsx
@@ -45,8 +45,8 @@ export default function FeedGridItem({
           className="aspect-square w-full object-cover"
         />
         <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0.6)_0%,rgba(0,0,0,0)_100%)]" />
-        <div className="absolute inset-x-3 top-3 flex items-center justify-between">
-          <div className="flex items-center gap-1 text-semantic-object-subtler [&_path]:fill-semantic-object-subtler">
+        <div className="absolute inset-x-3 top-3 flex items-start justify-between">
+          <div className="mt-1 flex items-center gap-1 text-semantic-object-subtler [&_path]:fill-semantic-object-subtler">
             <Icon name="clock" size={16} />
             <span className="caption-md">
               {formatStudyDuration(feed.studyTime)}

--- a/apps/web/src/entities/feed/ui/FeedGridItem.tsx
+++ b/apps/web/src/entities/feed/ui/FeedGridItem.tsx
@@ -42,7 +42,7 @@ export default function FeedGridItem({
           alt={`${feed.title}의 대표 이미지`}
           width={208}
           height={208}
-          className="w-full object-cover"
+          className="aspect-square w-full object-cover"
         />
         <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0.6)_0%,rgba(0,0,0,0)_100%)]" />
         <div className="absolute inset-x-3 top-3 flex items-center justify-between">

--- a/apps/web/src/entities/feed/ui/FeedListItem.tsx
+++ b/apps/web/src/entities/feed/ui/FeedListItem.tsx
@@ -7,8 +7,6 @@ import Image from 'next/image';
 import { Icon } from '@plog/ui';
 import { cn } from '@plog/utils';
 
-import { getCategoryLabel } from '@/entities/place';
-
 import { formatStudyDuration } from '../lib/format';
 import { type FeedPost } from '../model/types';
 import TagBadgeGroup from './TagBadgeGroup';
@@ -41,17 +39,23 @@ export default function FeedListItem({
         onClick && 'cursor-pointer',
       )}
     >
-      <Image
-        src={feed.postImages[0]}
-        alt={`${feed.title}의 대표 이미지`}
-        width={120}
-        height={120}
-        className="aspect-square rounded-xl"
-      />
+      <div className="relative size-30 overflow-hidden rounded-xl mobile:size-27">
+        <Image
+          src={feed.postImages[0]}
+          alt={`${feed.title}의 대표 이미지`}
+          fill
+          sizes="(max-width: 440px) 108px, 120px"
+          className="object-cover"
+        />
+      </div>
       <div className="flex min-w-0 flex-1 flex-col gap-2">
         <div className="relative">
           <div onClick={(event) => event.stopPropagation()}>
-            <TagBadgeGroup tags={feed.tags} maxVisible={2} />
+            <TagBadgeGroup
+              tags={feed.tags}
+              maxVisible={1}
+              popoverSide="right"
+            />
           </div>
           <div className="absolute top-0 right-0">{action}</div>
         </div>
@@ -64,16 +68,6 @@ export default function FeedListItem({
           </span>
         </div>
         <div className="flex gap-3">
-          <div className="flex items-center gap-1">
-            <Icon
-              name="pin"
-              size={16}
-              className="text-semantic-object-subtle"
-            />
-            <span className="caption-md text-semantic-object-bold">
-              {feed.placeCategory ? getCategoryLabel(feed.placeCategory) : ''}
-            </span>
-          </div>
           <div className="flex items-center gap-1">
             <Icon
               name="clock"

--- a/apps/web/src/entities/feed/ui/FeedListItem.tsx
+++ b/apps/web/src/entities/feed/ui/FeedListItem.tsx
@@ -7,6 +7,8 @@ import Image from 'next/image';
 import { Icon } from '@plog/ui';
 import { cn } from '@plog/utils';
 
+import { getCategoryLabel } from '@/entities/place';
+
 import { formatStudyDuration } from '../lib/format';
 import { type FeedPost } from '../model/types';
 import TagBadgeGroup from './TagBadgeGroup';
@@ -44,14 +46,14 @@ export default function FeedListItem({
         alt={`${feed.title}의 대표 이미지`}
         width={120}
         height={120}
-        className="rounded-xl"
+        className="aspect-square rounded-xl"
       />
-      <div className="flex min-w-0 flex-1 flex-col">
-        <div className="flex justify-between gap-3">
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
+        <div className="relative">
           <div onClick={(event) => event.stopPropagation()}>
             <TagBadgeGroup tags={feed.tags} maxVisible={2} />
           </div>
-          {action}
+          <div className="absolute top-0 right-0">{action}</div>
         </div>
         <div className="flex flex-1 flex-col gap-1">
           <span className="label-lg text-semantic-object-boldest">
@@ -69,7 +71,7 @@ export default function FeedListItem({
               className="text-semantic-object-subtle"
             />
             <span className="caption-md text-semantic-object-bold">
-              {feed.placeCategory ?? ''}
+              {feed.placeCategory ? getCategoryLabel(feed.placeCategory) : ''}
             </span>
           </div>
           <div className="flex items-center gap-1">

--- a/apps/web/src/entities/feed/ui/TagBadgeGroup.tsx
+++ b/apps/web/src/entities/feed/ui/TagBadgeGroup.tsx
@@ -45,6 +45,7 @@ export default function TagBadgeGroup({
       {hasHiddenTags && (
         <div className="relative">
           <button
+            className="block"
             type="button"
             aria-expanded={isExpanded}
             aria-controls={hiddenTagsId}

--- a/apps/web/src/entities/place/index.ts
+++ b/apps/web/src/entities/place/index.ts
@@ -1,3 +1,4 @@
+export { getCategoryLabel } from './lib/category-label';
 export type { PlaceCategory, PlaceCategoryValue } from './model/place-category';
 export { PLACE_CATEGORIES } from './model/place-category';
 export type { Place, PlaceLayer } from './model/types';

--- a/apps/web/src/entities/place/lib/category-label.ts
+++ b/apps/web/src/entities/place/lib/category-label.ts
@@ -1,0 +1,5 @@
+import { PLACE_CATEGORIES } from '../model/place-category';
+
+export function getCategoryLabel(value: string): string {
+  return PLACE_CATEGORIES.find((c) => c.value === value)?.label ?? value;
+}

--- a/apps/web/src/features/select-review-tags/ui/ReviewTagsSheet.tsx
+++ b/apps/web/src/features/select-review-tags/ui/ReviewTagsSheet.tsx
@@ -45,8 +45,6 @@ export default function ReviewTagsSheet({
   const activeCategory =
     TAG_CATEGORIES.find(({ title }) => title === activeCategoryTitle) ??
     TAG_CATEGORIES[0];
-  const hasSelectedTags = value.length > 0;
-
   const handleOpenChange = (nextOpen: boolean) => {
     if (nextOpen) {
       setDraftValue(value);
@@ -74,32 +72,11 @@ export default function ReviewTagsSheet({
     setDraftValue((current) => toggleTag(current, tag));
   };
 
-  const handleRemoveSelectedTag = (tag: PlaceTagValue) => {
-    onChange(value.filter((selectedTag) => selectedTag !== tag));
-  };
-
   return (
     <>
       {value.map((tag) => (
         <input key={tag} type="hidden" name={name} value={tag} />
       ))}
-      {hasSelectedTags && (
-        <div className="mb-4 flex flex-wrap gap-2">
-          {value.map((tag) => (
-            <Chip
-              key={tag}
-              size="small"
-              variant="soft"
-              pressed
-              className="[&>svg]:size-2.5"
-              onClick={() => handleRemoveSelectedTag(tag)}
-            >
-              {PLACE_TAG_LABELS[tag]}
-              <Icon name="close" boxed={false} />
-            </Chip>
-          ))}
-        </div>
-      )}
       <BottomSheet open={open} onOpenChange={handleOpenChange}>
         <BottomSheet.Trigger render={children} />
         <BottomSheet.Content className="max-w-layout gap-4 rounded-t-[20px] px-6 pt-5 pb-6">

--- a/apps/web/src/features/select-review-tags/ui/ReviewTagsSheet.tsx
+++ b/apps/web/src/features/select-review-tags/ui/ReviewTagsSheet.tsx
@@ -141,11 +141,10 @@ export default function ReviewTagsSheet({
                   size="small"
                   variant="soft"
                   pressed={selectedTagSet.has(tag)}
-                  className="[&>svg]:size-2.5"
                   onClick={() => handleToggleDraftTag(tag)}
                 >
                   {PLACE_TAG_LABELS[tag]}
-                  <Icon name="close" size={9} boxed={false} />
+                  <Icon name="close" size={16} />
                 </Chip>
               ))}
             </div>

--- a/apps/web/src/features/toggle-bookmark/api/client.ts
+++ b/apps/web/src/features/toggle-bookmark/api/client.ts
@@ -1,0 +1,5 @@
+import { clientApi } from '@/shared/api/client-api';
+
+export function postToggleBookmark(postId: number) {
+  return clientApi.post<{ isBookmarked: boolean }>(`/feed/bookmark/${postId}`);
+}

--- a/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
+++ b/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
@@ -54,9 +54,20 @@ export function useToggleBookmark() {
 
       return { snapshot };
     },
-    onError: (_err, _postId, context) => {
+    onError: (_err, postId, context) => {
       if (context?.snapshot) {
-        queryClient.setQueryData(FEED_QUERY_KEY, context.snapshot);
+        const original = context.snapshot.pages
+          .flatMap((p) => p.items)
+          .find((post) => post.postId === postId);
+        queryClient.setQueryData<InfiniteData<FeedPage>>(
+          FEED_QUERY_KEY,
+          (prev) =>
+            updateBookmarkInFeedCache(
+              prev,
+              postId,
+              original?.bookMark ?? false,
+            ),
+        );
       }
       toast({
         id: 'bookmark-error',

--- a/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
+++ b/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
@@ -32,6 +32,7 @@ function updateBookmarkInFeedCache(
 
 export function useToggleBookmark() {
   const queryClient = useQueryClient();
+
   const { toast } = useToast();
 
   const mutation = useMutation({

--- a/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
+++ b/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
@@ -1,28 +1,91 @@
 'use client';
 
-import { type InfiniteData, useQueryClient } from '@tanstack/react-query';
+import { useToast } from '@plog/ui';
+import {
+  type InfiniteData,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
 
 import { FEED_QUERY_KEY, type FeedPage } from '@/entities/feed';
 
+import { dialog } from '@/shared/lib/dialog';
+
+import { postToggleBookmark } from '../api/client';
+
+function updateBookmarkInFeedCache(
+  prev: InfiniteData<FeedPage> | undefined,
+  postId: number,
+  isBookmarked: boolean,
+): InfiniteData<FeedPage> | undefined {
+  if (!prev) return prev;
+  return {
+    ...prev,
+    pages: prev.pages.map((page) => ({
+      ...page,
+      items: page.items.map((post) =>
+        post.postId === postId ? { ...post, bookMark: isBookmarked } : post,
+      ),
+    })),
+  };
+}
+
 export function useToggleBookmark() {
   const queryClient = useQueryClient();
+  const { toast } = useToast();
 
-  const toggleBookmark = (postId: number) => {
-    queryClient.setQueryData<InfiniteData<FeedPage>>(FEED_QUERY_KEY, (prev) => {
-      if (!prev) return prev;
+  const mutation = useMutation({
+    mutationFn: postToggleBookmark,
+    onMutate: async (postId) => {
+      await queryClient.cancelQueries({ queryKey: FEED_QUERY_KEY });
+      const snapshot =
+        queryClient.getQueryData<InfiniteData<FeedPage>>(FEED_QUERY_KEY);
 
-      return {
-        ...prev,
-        pages: prev.pages.map((page) => ({
-          ...page,
-          items: page.items.map((post) =>
-            post.postId === postId
-              ? { ...post, bookMark: !post.bookMark }
-              : post,
-          ),
-        })),
-      };
-    });
+      queryClient.setQueryData<InfiniteData<FeedPage>>(
+        FEED_QUERY_KEY,
+        (prev) => {
+          const current = prev?.pages
+            .flatMap((p) => p.items)
+            .find((post) => post.postId === postId);
+          return updateBookmarkInFeedCache(prev, postId, !current?.bookMark);
+        },
+      );
+
+      return { snapshot };
+    },
+    onError: (_err, _postId, context) => {
+      if (context?.snapshot) {
+        queryClient.setQueryData(FEED_QUERY_KEY, context.snapshot);
+      }
+      toast({
+        id: 'bookmark-error',
+        type: 'error',
+        description: '북마크 처리 중 오류가 발생했어요.',
+      });
+    },
+    onSuccess: (res, postId) => {
+      queryClient.setQueryData<InfiniteData<FeedPage>>(FEED_QUERY_KEY, (prev) =>
+        updateBookmarkInFeedCache(prev, postId, res.isBookmarked),
+      );
+      queryClient.invalidateQueries({ queryKey: ['mypage'] });
+    },
+  });
+
+  const toggleBookmark = async (
+    postId: number,
+    isBookmarked: boolean,
+  ): Promise<boolean> => {
+    if (isBookmarked) {
+      const confirmed = await dialog.confirm({
+        message: '북마크를 취소하시겠어요?',
+        confirmLabel: '취소하기',
+        cancelLabel: '닫기',
+      });
+      if (!confirmed) return false;
+    }
+
+    mutation.mutate(postId);
+    return true;
   };
 
   return { toggleBookmark };

--- a/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
+++ b/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
@@ -89,5 +89,5 @@ export function useToggleBookmark() {
     return true;
   };
 
-  return { toggleBookmark };
+  return { toggleBookmark, isPending: mutation.isPending };
 }

--- a/apps/web/src/features/toggle-bookmark/ui/BookmarkButton.tsx
+++ b/apps/web/src/features/toggle-bookmark/ui/BookmarkButton.tsx
@@ -24,8 +24,9 @@ export default function BookmarkButton({
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    toggleBookmark(postId);
-    onToggle?.(postId);
+    toggleBookmark(postId, isBookmarked).then((proceeded) => {
+      if (proceeded) onToggle?.(postId);
+    });
   };
 
   return (

--- a/apps/web/src/features/toggle-bookmark/ui/BookmarkButton.tsx
+++ b/apps/web/src/features/toggle-bookmark/ui/BookmarkButton.tsx
@@ -38,13 +38,13 @@ export default function BookmarkButton({
       type="button"
       aria-label={optimisticBookmarked ? '북마크 취소' : '북마크'}
       aria-pressed={optimisticBookmarked}
-      className={cn('cursor-pointer', className)}
+      className={cn('cursor-pointer text-semantic-object-normal', className)}
       onClick={handleClick}
     >
       {optimisticBookmarked ? (
         <Icon name="bookmark-filled" className="text-semantic-accent-normal" />
       ) : (
-        <Icon name="bookmark" className="text-semantic-object-normal" />
+        <Icon name="bookmark" className="text-current" />
       )}
     </button>
   );

--- a/apps/web/src/features/toggle-bookmark/ui/BookmarkButton.tsx
+++ b/apps/web/src/features/toggle-bookmark/ui/BookmarkButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type MouseEvent } from 'react';
+import { type MouseEvent, useEffect, useState } from 'react';
 
 import { Icon } from '@plog/ui';
 import { cn } from '@plog/utils';
@@ -11,33 +11,37 @@ type BookmarkButtonProps = {
   postId: number;
   isBookmarked: boolean;
   className?: string;
-  onToggle?: (postId: number) => void;
 };
 
 export default function BookmarkButton({
   postId,
   isBookmarked,
   className,
-  onToggle,
 }: BookmarkButtonProps) {
+  const [optimisticBookmarked, setOptimisticBookmarked] =
+    useState(isBookmarked);
+
+  useEffect(() => {
+    setOptimisticBookmarked(isBookmarked);
+  }, [isBookmarked]);
+
   const { toggleBookmark } = useToggleBookmark();
 
-  const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+  const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    toggleBookmark(postId, isBookmarked).then((proceeded) => {
-      if (proceeded) onToggle?.(postId);
-    });
+    const proceeded = await toggleBookmark(postId, optimisticBookmarked);
+    if (proceeded) setOptimisticBookmarked((prev) => !prev);
   };
 
   return (
     <button
       type="button"
-      aria-label={isBookmarked ? '북마크 취소' : '북마크'}
-      aria-pressed={isBookmarked}
+      aria-label={optimisticBookmarked ? '북마크 취소' : '북마크'}
+      aria-pressed={optimisticBookmarked}
       className={cn('cursor-pointer', className)}
       onClick={handleClick}
     >
-      {isBookmarked ? (
+      {optimisticBookmarked ? (
         <Icon name="bookmark-filled" className="text-semantic-accent-normal" />
       ) : (
         <Icon name="bookmark" className="text-semantic-object-normal" />

--- a/apps/web/src/features/toggle-bookmark/ui/BookmarkButton.tsx
+++ b/apps/web/src/features/toggle-bookmark/ui/BookmarkButton.tsx
@@ -25,7 +25,7 @@ export default function BookmarkButton({
     setOptimisticBookmarked(isBookmarked);
   }, [isBookmarked]);
 
-  const { toggleBookmark } = useToggleBookmark();
+  const { toggleBookmark, isPending } = useToggleBookmark();
 
   const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
@@ -38,7 +38,11 @@ export default function BookmarkButton({
       type="button"
       aria-label={optimisticBookmarked ? '북마크 취소' : '북마크'}
       aria-pressed={optimisticBookmarked}
-      className={cn('cursor-pointer text-semantic-object-normal', className)}
+      className={cn(
+        'cursor-pointer text-semantic-object-normal disabled:cursor-not-allowed disabled:opacity-40',
+        className,
+      )}
+      disabled={isPending}
       onClick={handleClick}
     >
       {optimisticBookmarked ? (

--- a/apps/web/src/shared/ui/BookmarkEmptyState.tsx
+++ b/apps/web/src/shared/ui/BookmarkEmptyState.tsx
@@ -5,19 +5,21 @@ import { EmptyState } from '@plog/ui';
 import BookmarkEmptyGraphic from '@/shared/assets/empty-graphics/bookmark-empty.svg';
 
 type BookmarkEmptyStateProps = {
+  title?: string;
   description?: string;
   actions?: ReactNode;
   className?: string;
 };
 
 export default function BookmarkEmptyState({
+  title = '아직 북마크가 없어요',
   description = '마음에 드는 게시글에 북마크를 눌러 저장해 보세요.',
   actions,
   className,
 }: BookmarkEmptyStateProps) {
   return (
     <EmptyState
-      title="아직 북마크가 없어요"
+      title={title}
       description={description}
       graphic={<BookmarkEmptyGraphic />}
       actions={actions}

--- a/apps/web/src/shared/ui/BookmarkEmptyState.tsx
+++ b/apps/web/src/shared/ui/BookmarkEmptyState.tsx
@@ -1,0 +1,27 @@
+import { type ReactNode } from 'react';
+
+import { EmptyState } from '@plog/ui';
+
+import BookmarkEmptyGraphic from '@/shared/assets/empty-graphics/bookmark-empty.svg';
+
+type BookmarkEmptyStateProps = {
+  description?: string;
+  actions?: ReactNode;
+  className?: string;
+};
+
+export default function BookmarkEmptyState({
+  description = '마음에 드는 게시글에 북마크를 눌러 저장해 보세요.',
+  actions,
+  className,
+}: BookmarkEmptyStateProps) {
+  return (
+    <EmptyState
+      title="아직 북마크가 없어요"
+      description={description}
+      graphic={<BookmarkEmptyGraphic />}
+      actions={actions}
+      className={className}
+    />
+  );
+}

--- a/apps/web/src/shared/ui/FetchErrorEmptyState.tsx
+++ b/apps/web/src/shared/ui/FetchErrorEmptyState.tsx
@@ -1,0 +1,36 @@
+import { Button, EmptyState } from '@plog/ui';
+
+import LoadingEmptyGraphic from '@/shared/assets/empty-graphics/loading-empty.svg';
+
+type FetchErrorEmptyStateProps = {
+  description?: string;
+  onRetry?: () => void;
+  className?: string;
+};
+
+export default function FetchErrorEmptyState({
+  description = '인터넷 연결 상태를 확인하고 다시 시도해 주세요',
+  onRetry,
+  className,
+}: FetchErrorEmptyStateProps) {
+  return (
+    <EmptyState
+      title="정보를 불러오지 못했어요"
+      description={description}
+      graphic={<LoadingEmptyGraphic />}
+      actions={
+        onRetry && (
+          <Button
+            type="button"
+            variant="outline"
+            size="small"
+            onClick={onRetry}
+          >
+            다시 시도
+          </Button>
+        )
+      }
+      className={className}
+    />
+  );
+}

--- a/apps/web/src/shared/ui/FetchErrorEmptyState.tsx
+++ b/apps/web/src/shared/ui/FetchErrorEmptyState.tsx
@@ -3,19 +3,21 @@ import { Button, EmptyState } from '@plog/ui';
 import LoadingEmptyGraphic from '@/shared/assets/empty-graphics/loading-empty.svg';
 
 type FetchErrorEmptyStateProps = {
+  title?: string;
   description?: string;
   onRetry?: () => void;
   className?: string;
 };
 
 export default function FetchErrorEmptyState({
-  description = '인터넷 연결 상태를 확인하고 다시 시도해 주세요',
+  title = '정보를 불러오지 못했어요',
+  description = '인터넷 연결 상태를 확인하고 다시 시도해 주세요.',
   onRetry,
   className,
 }: FetchErrorEmptyStateProps) {
   return (
     <EmptyState
-      title="정보를 불러오지 못했어요"
+      title={title}
       description={description}
       graphic={<LoadingEmptyGraphic />}
       actions={

--- a/apps/web/src/shared/ui/PlaceSearchIdleState.tsx
+++ b/apps/web/src/shared/ui/PlaceSearchIdleState.tsx
@@ -3,17 +3,19 @@ import { EmptyState } from '@plog/ui';
 import PlaceEmptyGraphic from '@/shared/assets/empty-graphics/place-empty.svg';
 
 type PlaceSearchIdleStateProps = {
+  title?: string;
   description?: string;
   className?: string;
 };
 
 export default function PlaceSearchIdleState({
-  description = '오늘 몰입했던 그 장소를 검색해 보세요',
+  title = '어디에서 작업하셨나요?',
+  description = '오늘 몰입했던 그 장소를 검색해 보세요.',
   className,
 }: PlaceSearchIdleStateProps) {
   return (
     <EmptyState
-      title="어디에서 작업하셨나요?"
+      title={title}
       description={description}
       graphic={<PlaceEmptyGraphic />}
       className={className}

--- a/apps/web/src/shared/ui/PlaceSearchIdleState.tsx
+++ b/apps/web/src/shared/ui/PlaceSearchIdleState.tsx
@@ -1,0 +1,22 @@
+import { EmptyState } from '@plog/ui';
+
+import PlaceEmptyGraphic from '@/shared/assets/empty-graphics/place-empty.svg';
+
+type PlaceSearchIdleStateProps = {
+  description?: string;
+  className?: string;
+};
+
+export default function PlaceSearchIdleState({
+  description = '오늘 몰입했던 그 장소를 검색해 보세요',
+  className,
+}: PlaceSearchIdleStateProps) {
+  return (
+    <EmptyState
+      title="어디에서 작업하셨나요?"
+      description={description}
+      graphic={<PlaceEmptyGraphic />}
+      className={className}
+    />
+  );
+}

--- a/apps/web/src/shared/ui/RecordEmptyState.tsx
+++ b/apps/web/src/shared/ui/RecordEmptyState.tsx
@@ -5,19 +5,21 @@ import { EmptyState } from '@plog/ui';
 import RecordEmptyGraphic from '@/shared/assets/empty-graphics/record-empty.svg';
 
 type RecordEmptyStateProps = {
+  title?: string;
   description?: string;
   actions?: ReactNode;
   className?: string;
 };
 
 export default function RecordEmptyState({
+  title = '아직 기록이 없어요',
   description = '첫 번째 기록을 남겨볼까요?',
   actions,
   className,
 }: RecordEmptyStateProps) {
   return (
     <EmptyState
-      title="아직 기록이 없어요"
+      title={title}
       description={description}
       graphic={<RecordEmptyGraphic />}
       actions={actions}

--- a/apps/web/src/shared/ui/RecordEmptyState.tsx
+++ b/apps/web/src/shared/ui/RecordEmptyState.tsx
@@ -1,0 +1,27 @@
+import { type ReactNode } from 'react';
+
+import { EmptyState } from '@plog/ui';
+
+import RecordEmptyGraphic from '@/shared/assets/empty-graphics/record-empty.svg';
+
+type RecordEmptyStateProps = {
+  description?: string;
+  actions?: ReactNode;
+  className?: string;
+};
+
+export default function RecordEmptyState({
+  description = '첫 번째 기록을 남겨볼까요?',
+  actions,
+  className,
+}: RecordEmptyStateProps) {
+  return (
+    <EmptyState
+      title="아직 기록이 없어요"
+      description={description}
+      graphic={<RecordEmptyGraphic />}
+      actions={actions}
+      className={className}
+    />
+  );
+}

--- a/apps/web/src/shared/ui/SearchEmptyState.tsx
+++ b/apps/web/src/shared/ui/SearchEmptyState.tsx
@@ -3,17 +3,19 @@ import { EmptyState } from '@plog/ui';
 import SearchEmptyGraphic from '@/shared/assets/empty-graphics/search-empty.svg';
 
 type SearchEmptyStateProps = {
+  title?: string;
   description?: string;
   className?: string;
 };
 
 export default function SearchEmptyState({
-  description = '검색어를 다시 확인해 주세요',
+  title = '검색 결과가 없어요',
+  description = '검색어를 다시 확인해 주세요.',
   className,
 }: SearchEmptyStateProps) {
   return (
     <EmptyState
-      title="검색 결과가 없어요"
+      title={title}
       description={description}
       graphic={<SearchEmptyGraphic />}
       className={className}

--- a/apps/web/src/shared/ui/SearchEmptyState.tsx
+++ b/apps/web/src/shared/ui/SearchEmptyState.tsx
@@ -1,0 +1,22 @@
+import { EmptyState } from '@plog/ui';
+
+import SearchEmptyGraphic from '@/shared/assets/empty-graphics/search-empty.svg';
+
+type SearchEmptyStateProps = {
+  description?: string;
+  className?: string;
+};
+
+export default function SearchEmptyState({
+  description = '검색어를 다시 확인해 주세요',
+  className,
+}: SearchEmptyStateProps) {
+  return (
+    <EmptyState
+      title="검색 결과가 없어요"
+      description={description}
+      graphic={<SearchEmptyGraphic />}
+      className={className}
+    />
+  );
+}

--- a/apps/web/src/shared/ui/index.ts
+++ b/apps/web/src/shared/ui/index.ts
@@ -1,5 +1,10 @@
+export { default as BookmarkEmptyState } from './BookmarkEmptyState';
 export { default as BottomTab } from './BottomTab';
+export { default as FetchErrorEmptyState } from './FetchErrorEmptyState';
 export { default as GlobalDialog } from './GlobalDialog';
 export { default as ImageWithFallback } from './ImageWithFallback';
+export { default as PlaceSearchIdleState } from './PlaceSearchIdleState';
 export { default as Providers } from './Providers';
+export { default as RecordEmptyState } from './RecordEmptyState';
 export { default as ScrollToTopButton } from './ScrollToTopButton';
+export { default as SearchEmptyState } from './SearchEmptyState';

--- a/apps/web/src/views/feed/ui/FeedPage.tsx
+++ b/apps/web/src/views/feed/ui/FeedPage.tsx
@@ -5,10 +5,14 @@ import { useInView } from 'react-intersection-observer';
 
 import { useRouter } from 'next/navigation';
 
-import { Button, EmptyState, Icon, Spinner, useToast } from '@plog/ui';
+import { Button, Icon, Spinner, useToast } from '@plog/ui';
 
 import { useScrollToTop } from '@/shared/lib/scroll-to-top';
-import { ScrollToTopButton } from '@/shared/ui';
+import {
+  FetchErrorEmptyState,
+  RecordEmptyState,
+  ScrollToTopButton,
+} from '@/shared/ui';
 
 import { useInfiniteFeedQuery } from '../model/use-infinite-feed-query';
 import FeedCard from './FeedCard';
@@ -54,19 +58,9 @@ export default function FeedPage() {
   if (isError && posts.length === 0) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <EmptyState
-          title="데이터를 불러오지 못했습니다"
+        <FetchErrorEmptyState
           description="네트워크 연결 상태를 확인한 뒤 다시 시도해 주세요."
-          actions={
-            <Button
-              type="button"
-              variant="outline"
-              size="small"
-              onClick={() => refetch()}
-            >
-              다시 시도
-            </Button>
-          }
+          onRetry={refetch}
         />
       </div>
     );
@@ -75,9 +69,7 @@ export default function FeedPage() {
   if (posts.length === 0) {
     return (
       <div className="flex min-h-screen items-center justify-center">
-        <EmptyState
-          title="아직 올라온 기록이 없어요"
-          description="가장 먼저 기록을 남겨볼까요?"
+        <RecordEmptyState
           actions={
             <Button
               variant="outline"

--- a/apps/web/src/views/log-place-search/ui/SearchPlacePage.tsx
+++ b/apps/web/src/views/log-place-search/ui/SearchPlacePage.tsx
@@ -5,8 +5,6 @@ import { type ReactNode, useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import Script from 'next/script';
 
-import { Button, EmptyState } from '@plog/ui';
-
 import { PlaceSearchContent } from '@/widgets/place-search';
 
 import {
@@ -18,9 +16,11 @@ import {
   removeRecentPlace,
 } from '@/features/place-search';
 
-import LoadingEmptyGraphic from '@/shared/assets/empty-graphics/loading-empty.svg';
-import PlaceEmptyGraphic from '@/shared/assets/empty-graphics/place-empty.svg';
-import SearchEmptyGraphic from '@/shared/assets/empty-graphics/search-empty.svg';
+import {
+  FetchErrorEmptyState,
+  PlaceSearchIdleState,
+  SearchEmptyState,
+} from '@/shared/ui';
 
 import { useKakaoPlaceSearch } from '../lib/use-kakao-place-search';
 import SearchResultList from './SearchResultList';
@@ -100,38 +100,18 @@ export default function SearchPlacePage() {
             onRecentClear={() => setRecentPlaces(clearRecentPlaces())}
             idleView={
               <CenteredView>
-                <EmptyState
-                  title="어디에서 작업하셨나요?"
-                  description="오늘 몰입했던 그 장소를 검색해 보세요"
-                  graphic={<PlaceEmptyGraphic />}
-                />
+                <PlaceSearchIdleState />
               </CenteredView>
             }
             emptyView={
               <CenteredView>
-                <EmptyState
-                  title="검색 결과가 없어요"
-                  description="장소 이름이나 주소가 정확한지 확인해 주세요"
-                  graphic={<SearchEmptyGraphic />}
-                />
+                <SearchEmptyState description="장소 이름이나 주소가 정확한지 확인해 주세요" />
               </CenteredView>
             }
             errorView={
               <CenteredView>
-                <EmptyState
-                  title="정보를 불러오지 못했어요"
-                  description="인터넷 연결 상태를 확인하고 다시 시도해 주세요"
-                  graphic={<LoadingEmptyGraphic />}
-                  actions={
-                    <Button
-                      type="button"
-                      variant="outline"
-                      size="small"
-                      onClick={() => window.location.reload()}
-                    >
-                      새로 고침
-                    </Button>
-                  }
+                <FetchErrorEmptyState
+                  onRetry={() => window.location.reload()}
                 />
               </CenteredView>
             }

--- a/apps/web/src/views/log/ui/CreateLogPage.tsx
+++ b/apps/web/src/views/log/ui/CreateLogPage.tsx
@@ -11,6 +11,7 @@ import { useRouter } from 'next/navigation';
 
 import {
   Button,
+  Chip,
   type DateValue,
   Field,
   Icon,
@@ -26,7 +27,7 @@ import { ReviewTagsSheet } from '@/features/select-review-tags';
 import { formatDisplayDate, WorkDateDialog } from '@/features/select-work-date';
 import { formatTimeValue, WorkTimeDialog } from '@/features/select-work-time';
 
-import { PlaceTagValue } from '@/entities/feed';
+import { PLACE_TAG_LABELS, PlaceTagValue } from '@/entities/feed';
 import { getCategoryLabel, type PlaceCategoryValue } from '@/entities/place';
 
 import { usePhotoUpload } from '../model/use-photo-upload';
@@ -246,6 +247,25 @@ export default function CreateLogPage({
                 태그 추가하기
               </Button>
             </ReviewTagsSheet>
+            {reviewTags.length > 0 && (
+              <div className="mt-3 flex flex-wrap gap-2">
+                {reviewTags.map((tag) => (
+                  <Chip
+                    key={tag}
+                    size="small"
+                    variant="soft"
+                    pressed
+                    className="[&>svg]:size-2.5"
+                    onClick={() =>
+                      setReviewTags(reviewTags.filter((t) => t !== tag))
+                    }
+                  >
+                    {PLACE_TAG_LABELS[tag]}
+                    <Icon name="close" boxed={false} />
+                  </Chip>
+                ))}
+              </div>
+            )}
           </Field>
         </div>
       </section>

--- a/apps/web/src/views/log/ui/CreateLogPage.tsx
+++ b/apps/web/src/views/log/ui/CreateLogPage.tsx
@@ -27,7 +27,7 @@ import { formatDisplayDate, WorkDateDialog } from '@/features/select-work-date';
 import { formatTimeValue, WorkTimeDialog } from '@/features/select-work-time';
 
 import { PlaceTagValue } from '@/entities/feed';
-import { PLACE_CATEGORIES, type PlaceCategoryValue } from '@/entities/place';
+import { getCategoryLabel, type PlaceCategoryValue } from '@/entities/place';
 
 import { usePhotoUpload } from '../model/use-photo-upload';
 import PhotoUploader from './PhotoUploader';
@@ -151,10 +151,7 @@ export default function CreateLogPage({
           </Field>
           <PlaceCategorySheet value={placeCategory} onChange={setPlaceCategory}>
             <SelectTriggerButton
-              value={
-                PLACE_CATEGORIES.find((c) => c.value === placeCategory)
-                  ?.label ?? null
-              }
+              value={placeCategory ? getCategoryLabel(placeCategory) : null}
               placeholder="장소 카테고리를 선택해 주세요."
               icon={
                 <Icon

--- a/apps/web/src/views/log/ui/CreateLogPage.tsx
+++ b/apps/web/src/views/log/ui/CreateLogPage.tsx
@@ -255,13 +255,12 @@ export default function CreateLogPage({
                     size="small"
                     variant="soft"
                     pressed
-                    className="[&>svg]:size-2.5"
                     onClick={() =>
                       setReviewTags((prev) => prev.filter((t) => t !== tag))
                     }
                   >
                     {PLACE_TAG_LABELS[tag]}
-                    <Icon name="close" boxed={false} />
+                    <Icon name="close" size={16} />
                   </Chip>
                 ))}
               </div>

--- a/apps/web/src/views/log/ui/CreateLogPage.tsx
+++ b/apps/web/src/views/log/ui/CreateLogPage.tsx
@@ -27,7 +27,7 @@ import { ReviewTagsSheet } from '@/features/select-review-tags';
 import { formatDisplayDate, WorkDateDialog } from '@/features/select-work-date';
 import { formatTimeValue, WorkTimeDialog } from '@/features/select-work-time';
 
-import { PLACE_TAG_LABELS, PlaceTagValue } from '@/entities/feed';
+import { PLACE_TAG_LABELS, type PlaceTagValue } from '@/entities/feed';
 import { getCategoryLabel, type PlaceCategoryValue } from '@/entities/place';
 
 import { usePhotoUpload } from '../model/use-photo-upload';

--- a/apps/web/src/views/log/ui/CreateLogPage.tsx
+++ b/apps/web/src/views/log/ui/CreateLogPage.tsx
@@ -257,7 +257,7 @@ export default function CreateLogPage({
                     pressed
                     className="[&>svg]:size-2.5"
                     onClick={() =>
-                      setReviewTags(reviewTags.filter((t) => t !== tag))
+                      setReviewTags((prev) => prev.filter((t) => t !== tag))
                     }
                   >
                     {PLACE_TAG_LABELS[tag]}

--- a/apps/web/src/views/map/ui/MapListSheet.tsx
+++ b/apps/web/src/views/map/ui/MapListSheet.tsx
@@ -2,22 +2,13 @@
 
 import { type ReactNode, useMemo, useState } from 'react';
 
-import {
-  BottomSheet,
-  Button,
-  Divider,
-  EmptyState,
-  Icon,
-  Select,
-  Switch,
-} from '@plog/ui';
+import { BottomSheet, Button, Divider, Icon, Select, Switch } from '@plog/ui';
 
 import MapPlaceItem from '@/views/map/ui/MapPlaceItem';
 
 import { type Place, type PlaceLayer } from '@/entities/place';
 
-import BookmarkEmptyGraphic from '@/shared/assets/empty-graphics/bookmark-empty.svg';
-import RecordEmptyGraphic from '@/shared/assets/empty-graphics/record-empty.svg';
+import { BookmarkEmptyState, RecordEmptyState } from '@/shared/ui';
 
 type RecordSort = 'latest' | 'records' | 'worktime' | 'focus';
 type BookmarkSort = 'latest' | 'focus';
@@ -111,10 +102,7 @@ type PlaceListProps = {
   places: Place[];
   placeType: PlaceLayer;
   sortOptions: { value: string; label: string }[];
-  emptyGraphic?: ReactNode;
-  emptyTitle: string;
-  emptyDescription: string;
-  emptyActions?: ReactNode;
+  emptyView: ReactNode;
   onPlaceClick: (place: Place) => void;
 };
 
@@ -122,10 +110,7 @@ function PlaceList({
   places,
   placeType,
   sortOptions,
-  emptyGraphic,
-  emptyTitle,
-  emptyDescription,
-  emptyActions,
+  emptyView,
   onPlaceClick,
 }: PlaceListProps) {
   const [sort, setSort] = useState(sortOptions[0].value);
@@ -142,13 +127,7 @@ function PlaceList({
         />
       </div>
       {sorted.length === 0 ? (
-        <EmptyState
-          graphic={emptyGraphic}
-          title={emptyTitle}
-          description={emptyDescription}
-          actions={emptyActions}
-          className="flex-1 justify-center py-12"
-        />
+        emptyView
       ) : (
         <div className="relative min-h-0 flex-1">
           <div
@@ -285,13 +264,16 @@ export default function MapListSheet({
                 places={recordPlaces}
                 placeType="record"
                 sortOptions={RECORD_SORT_OPTIONS}
-                emptyTitle="아직 기록이 없어요"
-                emptyGraphic={<RecordEmptyGraphic />}
-                emptyDescription="오늘의 작업 일지나 기억하고 싶은 장소를\n첫 기록으로 남겨보세요."
-                emptyActions={
-                  <Button variant="outline" size="medium">
-                    기록 작성하기
-                  </Button>
+                emptyView={
+                  <RecordEmptyState
+                    description="오늘의 작업 일지나 기억하고 싶은 장소를\n첫 기록으로 남겨보세요."
+                    actions={
+                      <Button variant="outline" size="medium">
+                        기록 작성하기
+                      </Button>
+                    }
+                    className="flex-1 justify-center py-12"
+                  />
                 }
                 onPlaceClick={(place) => handlePlaceClick(place, 'record')}
               />
@@ -300,9 +282,12 @@ export default function MapListSheet({
                 places={bookmarkPlaces}
                 placeType="bookmark"
                 sortOptions={BOOKMARK_SORT_OPTIONS}
-                emptyGraphic={<BookmarkEmptyGraphic />}
-                emptyTitle="아직 북마크한 장소가 없어요"
-                emptyDescription="마음에 드는 장소를 발견하면\n북마크를 눌러 저장해 보세요."
+                emptyView={
+                  <BookmarkEmptyState
+                    description="마음에 드는 장소를 발견하면\n북마크를 눌러 저장해 보세요."
+                    className="flex-1 justify-center py-12"
+                  />
+                }
                 onPlaceClick={(place) => handlePlaceClick(place, 'bookmark')}
               />
             )}

--- a/apps/web/src/views/my/model/use-my-bookmarks-query.ts
+++ b/apps/web/src/views/my/model/use-my-bookmarks-query.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+
+import {
+  type BookmarkSortType,
+  type FeedPost,
+  type PlaceTagValue,
+} from '@/entities/feed';
+
+import { clientApi } from '@/shared/api/client-api';
+
+async function fetchMyBookmarks(sort: BookmarkSortType, tags: PlaceTagValue[]) {
+  const params = new URLSearchParams({ sort });
+  tags.forEach((tag) => params.append('tags', tag));
+  return clientApi.get<{ myBookmarks: FeedPost[] }>(
+    `/members/bookmark?${params}`,
+  );
+}
+
+export function useMyBookmarksQuery(
+  sort: BookmarkSortType,
+  tags: PlaceTagValue[] = [],
+) {
+  return useQuery({
+    queryKey: ['mypage', 'bookmarks', sort, tags],
+    queryFn: () => fetchMyBookmarks(sort, tags),
+    select: (data) => data.myBookmarks,
+  });
+}

--- a/apps/web/src/views/my/model/use-my-posts-query.ts
+++ b/apps/web/src/views/my/model/use-my-posts-query.ts
@@ -1,0 +1,28 @@
+import { useQuery } from '@tanstack/react-query';
+
+import {
+  type FeedPost,
+  type PlaceTagValue,
+  type PostSortType,
+} from '@/entities/feed';
+
+import { clientApi } from '@/shared/api/client-api';
+
+async function fetchMyPosts(sort: PostSortType, tags: PlaceTagValue[]) {
+  const params = new URLSearchParams({ sort });
+  tags.forEach((tag) => params.append('tags', tag));
+  return clientApi.get<{ posts: FeedPost[] }>(
+    `/members/mypage/posts?${params}`,
+  );
+}
+
+export function useMyPostsQuery(
+  sort: PostSortType,
+  tags: PlaceTagValue[] = [],
+) {
+  return useQuery({
+    queryKey: ['mypage', 'posts', sort, tags],
+    queryFn: () => fetchMyPosts(sort, tags),
+    select: (data) => data.posts,
+  });
+}

--- a/apps/web/src/views/my/ui/BookmarkTab.tsx
+++ b/apps/web/src/views/my/ui/BookmarkTab.tsx
@@ -6,6 +6,8 @@ import { FeedList, type RecordTypeValue } from '@/widgets/feed-list';
 
 import { type BookmarkSortType, type PlaceTagValue } from '@/entities/feed';
 
+import { BookmarkEmptyState, FetchErrorEmptyState } from '@/shared/ui';
+
 import { useMyBookmarksQuery } from '../model/use-my-bookmarks-query';
 
 const SORT_ITEMS: { value: RecordTypeValue; label: string }[] = [
@@ -16,10 +18,33 @@ const SORT_ITEMS: { value: RecordTypeValue; label: string }[] = [
 export default function BookmarkTab() {
   const [sort, setSort] = useState<BookmarkSortType>('latest');
   const [tags, setTags] = useState<PlaceTagValue[]>([]);
-  const { data: feeds = [] } = useMyBookmarksQuery(sort, tags);
+  const {
+    data: feeds = [],
+    isPending,
+    isError,
+  } = useMyBookmarksQuery(sort, tags);
+
+  if (isPending) return null;
+
+  if (isError) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <FetchErrorEmptyState />
+      </div>
+    );
+  }
+
+  if (feeds.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <BookmarkEmptyState />
+      </div>
+    );
+  }
 
   return (
     <FeedList
+      className="pt-6"
       feeds={feeds}
       sort={sort}
       onSortChange={(v) => setSort(v as BookmarkSortType)}

--- a/apps/web/src/views/my/ui/BookmarkTab.tsx
+++ b/apps/web/src/views/my/ui/BookmarkTab.tsx
@@ -2,13 +2,23 @@
 
 import { useState } from 'react';
 
-import { FeedList, type RecordTypeValue } from '@/widgets/feed-list';
+import { cn } from '@plog/utils';
+
+import {
+  FeedList,
+  type FeedViewType,
+  type RecordTypeValue,
+} from '@/widgets/feed-list';
+
+import { BookmarkButton } from '@/features/toggle-bookmark';
 
 import { type BookmarkSortType, type PlaceTagValue } from '@/entities/feed';
 
 import { BookmarkEmptyState, FetchErrorEmptyState } from '@/shared/ui';
 
 import { useMyBookmarksQuery } from '../model/use-my-bookmarks-query';
+
+type BookmarkByPostId = Record<number, boolean>;
 
 const SORT_ITEMS: { value: RecordTypeValue; label: string }[] = [
   { value: 'latest', label: '최신순' },
@@ -18,11 +28,20 @@ const SORT_ITEMS: { value: RecordTypeValue; label: string }[] = [
 export default function BookmarkTab() {
   const [sort, setSort] = useState<BookmarkSortType>('latest');
   const [tags, setTags] = useState<PlaceTagValue[]>([]);
+  const [bookmarks, setBookmarks] = useState<BookmarkByPostId>({});
   const {
     data: feeds = [],
     isPending,
     isError,
   } = useMyBookmarksQuery(sort, tags);
+
+  const handleBookmark = (postId: number) => {
+    setBookmarks((prev) => {
+      const feed = feeds.find((item) => item.postId === postId);
+      const current = prev[postId] ?? feed?.bookMark ?? false;
+      return { ...prev, [postId]: !current };
+    });
+  };
 
   if (isPending) return null;
 
@@ -52,6 +71,22 @@ export default function BookmarkTab() {
       tags={tags}
       onTagsChange={setTags}
       toolbarConfig={{ viewToggle: true, tagFilter: true }}
+      renderAction={(feed, viewType: FeedViewType) => {
+        const isBookmarked = bookmarks[feed.postId] ?? feed.bookMark;
+        return (
+          <BookmarkButton
+            postId={feed.postId}
+            isBookmarked={isBookmarked}
+            onToggle={handleBookmark}
+            className={cn(
+              viewType === 'grid' &&
+                (isBookmarked
+                  ? '[&_path]:fill-semantic-accent-normal'
+                  : '[&_path]:fill-semantic-object-subtler'),
+            )}
+          />
+        );
+      }}
     />
   );
 }

--- a/apps/web/src/views/my/ui/BookmarkTab.tsx
+++ b/apps/web/src/views/my/ui/BookmarkTab.tsx
@@ -54,8 +54,14 @@ export default function BookmarkTab() {
       tags={tags}
       onTagsChange={setTags}
       toolbarConfig={{ viewToggle: true, tagFilter: true }}
-      renderAction={(feed) => (
-        <BookmarkButton postId={feed.postId} isBookmarked={feed.bookMark} />
+      renderAction={(feed, viewType) => (
+        <BookmarkButton
+          className={
+            viewType === 'grid' ? 'text-semantic-object-subtle' : undefined
+          }
+          postId={feed.postId}
+          isBookmarked={feed.bookMark}
+        />
       )}
     />
   );

--- a/apps/web/src/views/my/ui/BookmarkTab.tsx
+++ b/apps/web/src/views/my/ui/BookmarkTab.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { useState } from 'react';
+
+import { FeedList, type RecordTypeValue } from '@/widgets/feed-list';
+
+import { type BookmarkSortType, type PlaceTagValue } from '@/entities/feed';
+
+import { useMyBookmarksQuery } from '../model/use-my-bookmarks-query';
+
+const SORT_ITEMS: { value: RecordTypeValue; label: string }[] = [
+  { value: 'latest', label: '최신순' },
+  { value: 'likes', label: '좋아요순' },
+];
+
+export default function BookmarkTab() {
+  const [sort, setSort] = useState<BookmarkSortType>('latest');
+  const [tags, setTags] = useState<PlaceTagValue[]>([]);
+  const { data: feeds = [] } = useMyBookmarksQuery(sort, tags);
+
+  return (
+    <FeedList
+      feeds={feeds}
+      sort={sort}
+      onSortChange={(v) => setSort(v as BookmarkSortType)}
+      sortItems={SORT_ITEMS}
+      tags={tags}
+      onTagsChange={setTags}
+      toolbarConfig={{ viewToggle: true, tagFilter: true }}
+    />
+  );
+}

--- a/apps/web/src/views/my/ui/BookmarkTab.tsx
+++ b/apps/web/src/views/my/ui/BookmarkTab.tsx
@@ -37,7 +37,7 @@ export default function BookmarkTab() {
     );
   }
 
-  if (feeds.length === 0) {
+  if (feeds.length === 0 && tags.length === 0) {
     return (
       <div className="flex flex-1 items-center justify-center">
         <BookmarkEmptyState />
@@ -55,6 +55,14 @@ export default function BookmarkTab() {
       tags={tags}
       onTagsChange={setTags}
       toolbarConfig={{ viewToggle: true, tagFilter: true }}
+      emptyView={
+        <div className="flex flex-1 items-center justify-center py-20">
+          <BookmarkEmptyState
+            title="일치하는 정보가 없어요"
+            description="다른 태그를 선택해 보세요."
+          />
+        </div>
+      }
       renderAction={(feed, viewType) => (
         <BookmarkButton
           className={

--- a/apps/web/src/views/my/ui/BookmarkTab.tsx
+++ b/apps/web/src/views/my/ui/BookmarkTab.tsx
@@ -2,13 +2,7 @@
 
 import { useState } from 'react';
 
-import { cn } from '@plog/utils';
-
-import {
-  FeedList,
-  type FeedViewType,
-  type RecordTypeValue,
-} from '@/widgets/feed-list';
+import { FeedList, type RecordTypeValue } from '@/widgets/feed-list';
 
 import { BookmarkButton } from '@/features/toggle-bookmark';
 
@@ -18,8 +12,6 @@ import { BookmarkEmptyState, FetchErrorEmptyState } from '@/shared/ui';
 
 import { useMyBookmarksQuery } from '../model/use-my-bookmarks-query';
 
-type BookmarkByPostId = Record<number, boolean>;
-
 const SORT_ITEMS: { value: RecordTypeValue; label: string }[] = [
   { value: 'latest', label: '최신순' },
   { value: 'likes', label: '좋아요순' },
@@ -28,20 +20,11 @@ const SORT_ITEMS: { value: RecordTypeValue; label: string }[] = [
 export default function BookmarkTab() {
   const [sort, setSort] = useState<BookmarkSortType>('latest');
   const [tags, setTags] = useState<PlaceTagValue[]>([]);
-  const [bookmarks, setBookmarks] = useState<BookmarkByPostId>({});
   const {
     data: feeds = [],
     isPending,
     isError,
   } = useMyBookmarksQuery(sort, tags);
-
-  const handleBookmark = (postId: number) => {
-    setBookmarks((prev) => {
-      const feed = feeds.find((item) => item.postId === postId);
-      const current = prev[postId] ?? feed?.bookMark ?? false;
-      return { ...prev, [postId]: !current };
-    });
-  };
 
   if (isPending) return null;
 
@@ -71,22 +54,9 @@ export default function BookmarkTab() {
       tags={tags}
       onTagsChange={setTags}
       toolbarConfig={{ viewToggle: true, tagFilter: true }}
-      renderAction={(feed, viewType: FeedViewType) => {
-        const isBookmarked = bookmarks[feed.postId] ?? feed.bookMark;
-        return (
-          <BookmarkButton
-            postId={feed.postId}
-            isBookmarked={isBookmarked}
-            onToggle={handleBookmark}
-            className={cn(
-              viewType === 'grid' &&
-                (isBookmarked
-                  ? '[&_path]:fill-semantic-accent-normal'
-                  : '[&_path]:fill-semantic-object-subtler'),
-            )}
-          />
-        );
-      }}
+      renderAction={(feed) => (
+        <BookmarkButton postId={feed.postId} isBookmarked={feed.bookMark} />
+      )}
     />
   );
 }

--- a/apps/web/src/views/my/ui/BookmarkTab.tsx
+++ b/apps/web/src/views/my/ui/BookmarkTab.tsx
@@ -24,6 +24,7 @@ export default function BookmarkTab() {
     data: feeds = [],
     isPending,
     isError,
+    refetch,
   } = useMyBookmarksQuery(sort, tags);
 
   if (isPending) return null;
@@ -31,7 +32,7 @@ export default function BookmarkTab() {
   if (isError) {
     return (
       <div className="flex flex-1 items-center justify-center">
-        <FetchErrorEmptyState />
+        <FetchErrorEmptyState onRetry={refetch} />
       </div>
     );
   }

--- a/apps/web/src/views/my/ui/MyPage.tsx
+++ b/apps/web/src/views/my/ui/MyPage.tsx
@@ -58,12 +58,14 @@ export default function MyPage() {
           }
         />
       </header>
-      <div className="pt-[var(--spacing-header)]">
+      <div className="flex min-h-[calc(100dvh-var(--spacing-bottom-tab))] flex-col pt-[var(--spacing-header)]">
         <ProfileSection />
         <TabGroup
           items={TABS}
           defaultValue="record"
+          className="flex flex-1 flex-col"
           listClassName="sticky top-[var(--spacing-header)] z-10 border-b border-b-semantic-stroke-subtle bg-semantic-bg-standard"
+          panelClassName="flex flex-1"
         />
       </div>
     </>

--- a/apps/web/src/views/my/ui/MyPage.tsx
+++ b/apps/web/src/views/my/ui/MyPage.tsx
@@ -3,7 +3,9 @@
 import { AppBar, Icon, TabGroup } from '@plog/ui';
 
 import AnalysisTab from './analysis/AnalysisTab';
+import BookmarkTab from './BookmarkTab';
 import ProfileSection from './ProfileSection';
+import RecordTab from './RecordTab';
 
 const TABS = [
   {
@@ -11,24 +13,14 @@ const TABS = [
     label: '기록',
     icon: <Icon name="pencil" size={20} />,
     activeIcon: <Icon name="pencil-filled" size={20} />,
-    panel: (
-      <div className="flex items-center justify-center py-20 text-semantic-object-subtle">
-        <p className="body-sm">기록 탭은 준비 중이에요.</p>
-      </div>
-    ),
-    disabled: true,
+    panel: <RecordTab />,
   },
   {
     value: 'bookmark',
     label: '북마크',
     icon: <Icon name="bookmark" size={20} />,
     activeIcon: <Icon name="bookmark-filled" size={20} />,
-    panel: (
-      <div className="flex items-center justify-center py-20 text-semantic-object-subtle">
-        <p className="body-sm">북마크 탭은 준비 중이에요.</p>
-      </div>
-    ),
-    disabled: true,
+    panel: <BookmarkTab />,
   },
   {
     value: 'badge',
@@ -70,7 +62,7 @@ export default function MyPage() {
         <ProfileSection />
         <TabGroup
           items={TABS}
-          defaultValue="analysis"
+          defaultValue="record"
           listClassName="sticky top-[var(--spacing-header)] z-10 border-b border-b-semantic-stroke-subtle bg-semantic-bg-standard"
         />
       </div>

--- a/apps/web/src/views/my/ui/RecordTab.tsx
+++ b/apps/web/src/views/my/ui/RecordTab.tsx
@@ -21,14 +21,19 @@ const SORT_ITEMS: { value: RecordTypeValue; label: string }[] = [
 export default function RecordTab() {
   const [sort, setSort] = useState<PostSortType>('latest');
   const [tags, setTags] = useState<PlaceTagValue[]>([]);
-  const { data: feeds = [], isPending, isError } = useMyPostsQuery(sort, tags);
+  const {
+    data: feeds = [],
+    isPending,
+    isError,
+    refetch,
+  } = useMyPostsQuery(sort, tags);
 
   if (isPending) return null;
 
   if (isError) {
     return (
       <div className="flex flex-1 items-center justify-center">
-        <FetchErrorEmptyState />
+        <FetchErrorEmptyState onRetry={refetch} />
       </div>
     );
   }

--- a/apps/web/src/views/my/ui/RecordTab.tsx
+++ b/apps/web/src/views/my/ui/RecordTab.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { useState } from 'react';
+
+import { FeedList, type RecordTypeValue } from '@/widgets/feed-list';
+
+import { type PlaceTagValue, type PostSortType } from '@/entities/feed';
+
+import { useMyPostsQuery } from '../model/use-my-posts-query';
+
+const SORT_ITEMS: { value: RecordTypeValue; label: string }[] = [
+  { value: 'latest', label: '최신순' },
+  { value: 'focus', label: '집중도순' },
+  { value: 'studyTime', label: '작업시간순' },
+];
+
+export default function RecordTab() {
+  const [sort, setSort] = useState<PostSortType>('latest');
+  const [tags, setTags] = useState<PlaceTagValue[]>([]);
+  const { data: feeds = [] } = useMyPostsQuery(sort, tags);
+
+  return (
+    <FeedList
+      feeds={feeds}
+      sort={sort}
+      onSortChange={(v) => setSort(v as PostSortType)}
+      sortItems={SORT_ITEMS}
+      tags={tags}
+      onTagsChange={setTags}
+      toolbarConfig={{ viewToggle: true, tagFilter: true }}
+    />
+  );
+}

--- a/apps/web/src/views/my/ui/RecordTab.tsx
+++ b/apps/web/src/views/my/ui/RecordTab.tsx
@@ -6,6 +6,8 @@ import { FeedList, type RecordTypeValue } from '@/widgets/feed-list';
 
 import { type PlaceTagValue, type PostSortType } from '@/entities/feed';
 
+import { FetchErrorEmptyState, RecordEmptyState } from '@/shared/ui';
+
 import { useMyPostsQuery } from '../model/use-my-posts-query';
 
 const SORT_ITEMS: { value: RecordTypeValue; label: string }[] = [
@@ -17,10 +19,29 @@ const SORT_ITEMS: { value: RecordTypeValue; label: string }[] = [
 export default function RecordTab() {
   const [sort, setSort] = useState<PostSortType>('latest');
   const [tags, setTags] = useState<PlaceTagValue[]>([]);
-  const { data: feeds = [] } = useMyPostsQuery(sort, tags);
+  const { data: feeds = [], isPending, isError } = useMyPostsQuery(sort, tags);
+
+  if (isPending) return null;
+
+  if (isError) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <FetchErrorEmptyState />
+      </div>
+    );
+  }
+
+  if (feeds.length === 0) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <RecordEmptyState />
+      </div>
+    );
+  }
 
   return (
     <FeedList
+      className="pt-6"
       feeds={feeds}
       sort={sort}
       onSortChange={(v) => setSort(v as PostSortType)}

--- a/apps/web/src/views/my/ui/RecordTab.tsx
+++ b/apps/web/src/views/my/ui/RecordTab.tsx
@@ -51,8 +51,14 @@ export default function RecordTab() {
       tags={tags}
       onTagsChange={setTags}
       toolbarConfig={{ viewToggle: true, tagFilter: true }}
-      renderAction={(feed) => (
-        <BookmarkButton postId={feed.postId} isBookmarked={feed.bookMark} />
+      renderAction={(feed, viewType) => (
+        <BookmarkButton
+          postId={feed.postId}
+          isBookmarked={feed.bookMark}
+          className={
+            viewType === 'grid' ? 'text-semantic-object-subtle' : undefined
+          }
+        />
       )}
     />
   );

--- a/apps/web/src/views/my/ui/RecordTab.tsx
+++ b/apps/web/src/views/my/ui/RecordTab.tsx
@@ -38,7 +38,7 @@ export default function RecordTab() {
     );
   }
 
-  if (feeds.length === 0) {
+  if (feeds.length === 0 && tags.length === 0) {
     return (
       <div className="flex flex-1 items-center justify-center">
         <RecordEmptyState />
@@ -56,6 +56,14 @@ export default function RecordTab() {
       tags={tags}
       onTagsChange={setTags}
       toolbarConfig={{ viewToggle: true, tagFilter: true }}
+      emptyView={
+        <div className="flex flex-1 items-center justify-center py-20">
+          <RecordEmptyState
+            title="일치하는 정보가 없어요"
+            description="다른 태그를 선택해 보세요."
+          />
+        </div>
+      }
       renderAction={(feed, viewType) => (
         <BookmarkButton
           postId={feed.postId}

--- a/apps/web/src/views/my/ui/RecordTab.tsx
+++ b/apps/web/src/views/my/ui/RecordTab.tsx
@@ -2,13 +2,23 @@
 
 import { useState } from 'react';
 
-import { FeedList, type RecordTypeValue } from '@/widgets/feed-list';
+import { cn } from '@plog/utils';
+
+import {
+  FeedList,
+  type FeedViewType,
+  type RecordTypeValue,
+} from '@/widgets/feed-list';
+
+import { BookmarkButton } from '@/features/toggle-bookmark';
 
 import { type PlaceTagValue, type PostSortType } from '@/entities/feed';
 
 import { FetchErrorEmptyState, RecordEmptyState } from '@/shared/ui';
 
 import { useMyPostsQuery } from '../model/use-my-posts-query';
+
+type BookmarkByPostId = Record<number, boolean>;
 
 const SORT_ITEMS: { value: RecordTypeValue; label: string }[] = [
   { value: 'latest', label: '최신순' },
@@ -19,7 +29,16 @@ const SORT_ITEMS: { value: RecordTypeValue; label: string }[] = [
 export default function RecordTab() {
   const [sort, setSort] = useState<PostSortType>('latest');
   const [tags, setTags] = useState<PlaceTagValue[]>([]);
+  const [bookmarks, setBookmarks] = useState<BookmarkByPostId>({});
   const { data: feeds = [], isPending, isError } = useMyPostsQuery(sort, tags);
+
+  const handleBookmark = (postId: number) => {
+    setBookmarks((prev) => {
+      const feed = feeds.find((item) => item.postId === postId);
+      const current = prev[postId] ?? feed?.bookMark ?? false;
+      return { ...prev, [postId]: !current };
+    });
+  };
 
   if (isPending) return null;
 
@@ -49,6 +68,22 @@ export default function RecordTab() {
       tags={tags}
       onTagsChange={setTags}
       toolbarConfig={{ viewToggle: true, tagFilter: true }}
+      renderAction={(feed, viewType: FeedViewType) => {
+        const isBookmarked = bookmarks[feed.postId] ?? feed.bookMark;
+        return (
+          <BookmarkButton
+            postId={feed.postId}
+            isBookmarked={isBookmarked}
+            onToggle={handleBookmark}
+            className={cn(
+              viewType === 'grid' &&
+                (isBookmarked
+                  ? '[&_path]:fill-semantic-accent-normal'
+                  : '[&_path]:fill-semantic-object-subtler'),
+            )}
+          />
+        );
+      }}
     />
   );
 }

--- a/apps/web/src/views/my/ui/RecordTab.tsx
+++ b/apps/web/src/views/my/ui/RecordTab.tsx
@@ -2,13 +2,7 @@
 
 import { useState } from 'react';
 
-import { cn } from '@plog/utils';
-
-import {
-  FeedList,
-  type FeedViewType,
-  type RecordTypeValue,
-} from '@/widgets/feed-list';
+import { FeedList, type RecordTypeValue } from '@/widgets/feed-list';
 
 import { BookmarkButton } from '@/features/toggle-bookmark';
 
@@ -17,8 +11,6 @@ import { type PlaceTagValue, type PostSortType } from '@/entities/feed';
 import { FetchErrorEmptyState, RecordEmptyState } from '@/shared/ui';
 
 import { useMyPostsQuery } from '../model/use-my-posts-query';
-
-type BookmarkByPostId = Record<number, boolean>;
 
 const SORT_ITEMS: { value: RecordTypeValue; label: string }[] = [
   { value: 'latest', label: '최신순' },
@@ -29,16 +21,7 @@ const SORT_ITEMS: { value: RecordTypeValue; label: string }[] = [
 export default function RecordTab() {
   const [sort, setSort] = useState<PostSortType>('latest');
   const [tags, setTags] = useState<PlaceTagValue[]>([]);
-  const [bookmarks, setBookmarks] = useState<BookmarkByPostId>({});
   const { data: feeds = [], isPending, isError } = useMyPostsQuery(sort, tags);
-
-  const handleBookmark = (postId: number) => {
-    setBookmarks((prev) => {
-      const feed = feeds.find((item) => item.postId === postId);
-      const current = prev[postId] ?? feed?.bookMark ?? false;
-      return { ...prev, [postId]: !current };
-    });
-  };
 
   if (isPending) return null;
 
@@ -68,22 +51,9 @@ export default function RecordTab() {
       tags={tags}
       onTagsChange={setTags}
       toolbarConfig={{ viewToggle: true, tagFilter: true }}
-      renderAction={(feed, viewType: FeedViewType) => {
-        const isBookmarked = bookmarks[feed.postId] ?? feed.bookMark;
-        return (
-          <BookmarkButton
-            postId={feed.postId}
-            isBookmarked={isBookmarked}
-            onToggle={handleBookmark}
-            className={cn(
-              viewType === 'grid' &&
-                (isBookmarked
-                  ? '[&_path]:fill-semantic-accent-normal'
-                  : '[&_path]:fill-semantic-object-subtler'),
-            )}
-          />
-        );
-      }}
+      renderAction={(feed) => (
+        <BookmarkButton postId={feed.postId} isBookmarked={feed.bookMark} />
+      )}
     />
   );
 }

--- a/apps/web/src/views/my/ui/analysis/SpaceRankingsSection.tsx
+++ b/apps/web/src/views/my/ui/analysis/SpaceRankingsSection.tsx
@@ -1,7 +1,7 @@
 import { Icon, type IconName } from '@plog/ui';
 import { cn } from '@plog/utils';
 
-import { PLACE_CATEGORIES } from '@/entities/place/model/place-category';
+import { getCategoryLabel } from '@/entities/place';
 import { type AnalyticsSpaceRanking } from '@/entities/user';
 
 const CATEGORY_ICONS: Record<string, IconName> = {
@@ -12,10 +12,6 @@ const CATEGORY_ICONS: Record<string, IconName> = {
   'shared-office': 'company-filled',
   etc: 'inbox-filled',
 };
-
-function getCategoryLabel(value: string) {
-  return PLACE_CATEGORIES.find((c) => c.value === value)?.label ?? value;
-}
 
 const EMPTY_SLOTS: null[] = [null, null, null];
 

--- a/apps/web/src/views/my/ui/analysis/StatsCards.tsx
+++ b/apps/web/src/views/my/ui/analysis/StatsCards.tsx
@@ -42,7 +42,7 @@ export default function StatsCards({
       <StatCard
         icon="clock"
         label="작업 시간"
-        value={totalStudyTime}
+        value={Math.floor(totalStudyTime / 60)}
         unit="h"
       />
     </div>

--- a/apps/web/src/views/users-detail/ui/UserFeedSection.tsx
+++ b/apps/web/src/views/users-detail/ui/UserFeedSection.tsx
@@ -22,11 +22,17 @@ import { ScrollToTopButton } from '@/shared/ui';
 
 type BookmarkByPostId = Record<number, boolean>;
 
+const SORT_ITEMS: { value: RecordTypeValue; label: string }[] = [
+  { value: 'latest', label: '최신순' },
+  { value: 'likes', label: '좋아요순' },
+  { value: 'focus', label: '집중도순' },
+];
+
 function sortFeeds(feeds: FeedPost[], sort: RecordTypeValue): FeedPost[] {
   return [...feeds].sort((a, b) => {
     if (sort === 'latest') return b.createAt.localeCompare(a.createAt);
-    if (sort === 'like') return b.likes - a.likes;
-    if (sort === 'concentrate') return b.focus - a.focus;
+    if (sort === 'likes') return b.likes - a.likes;
+    if (sort === 'focus') return b.focus - a.focus;
     return 0;
   });
 }
@@ -67,6 +73,7 @@ export default function UserFeedSection({ userId }: { userId: string }) {
         feeds={sortedFeeds}
         sort={sort}
         onSortChange={setSort}
+        sortItems={SORT_ITEMS}
         onFeedClick={handleFeedClick}
         toolbarConfig={{ viewToggle: true }}
         renderAction={(feed, viewType: FeedViewType) => {

--- a/apps/web/src/widgets/feed-list/model/types.ts
+++ b/apps/web/src/widgets/feed-list/model/types.ts
@@ -1,14 +1,7 @@
-export type RecordTypeValue = 'latest' | 'like' | 'concentrate';
+export type RecordTypeValue = 'latest' | 'focus' | 'studyTime' | 'likes';
 export type FeedViewType = 'list' | 'grid';
 
 export type ToolbarConfig = {
   viewToggle?: boolean;
   tagFilter?: boolean;
 };
-
-export const RECORD_OPTION_ITEMS: { value: RecordTypeValue; label: string }[] =
-  [
-    { value: 'latest', label: '최신순' },
-    { value: 'like', label: '좋아요순' },
-    { value: 'concentrate', label: '집중도순' },
-  ];

--- a/apps/web/src/widgets/feed-list/ui/FeedList.tsx
+++ b/apps/web/src/widgets/feed-list/ui/FeedList.tsx
@@ -32,6 +32,7 @@ type FeedListProps = {
   renderAction?: (feed: FeedPost, viewType: FeedViewType) => ReactNode;
   onFeedClick?: (feed: FeedPost) => void;
   toolbarConfig?: ToolbarConfig;
+  emptyView?: ReactNode;
   className?: string;
 };
 
@@ -45,6 +46,7 @@ export default function FeedList({
   renderAction,
   onFeedClick,
   toolbarConfig,
+  emptyView,
   className,
 }: FeedListProps) {
   const { viewType, toggleViewType } = useFeedViewType();
@@ -116,7 +118,9 @@ export default function FeedList({
           ))}
         </div>
       )}
-      {viewType === 'list' ? (
+      {feeds.length === 0 ? (
+        emptyView
+      ) : viewType === 'list' ? (
         <div>
           {feeds.map((feed) => (
             <FeedListItem

--- a/apps/web/src/widgets/feed-list/ui/FeedList.tsx
+++ b/apps/web/src/widgets/feed-list/ui/FeedList.tsx
@@ -2,13 +2,20 @@
 
 import { type ReactNode } from 'react';
 
-import { Icon, IconButton, Select } from '@plog/ui';
+import { Chip, Icon, IconButton, Select } from '@plog/ui';
 
-import { FeedGridItem, FeedListItem, type FeedPost } from '@/entities/feed';
+import { ReviewTagsSheet } from '@/features/select-review-tags';
+
+import {
+  FeedGridItem,
+  FeedListItem,
+  type FeedPost,
+  PLACE_TAG_LABELS,
+  type PlaceTagValue,
+} from '@/entities/feed';
 
 import {
   type FeedViewType,
-  RECORD_OPTION_ITEMS,
   type RecordTypeValue,
   type ToolbarConfig,
 } from '../model/types';
@@ -18,20 +25,22 @@ type FeedListProps = {
   feeds: FeedPost[];
   sort: RecordTypeValue;
   onSortChange: (sort: RecordTypeValue) => void;
+  sortItems: { value: RecordTypeValue; label: string }[];
+  tags?: PlaceTagValue[];
+  onTagsChange?: (tags: PlaceTagValue[]) => void;
   renderAction?: (feed: FeedPost, viewType: FeedViewType) => ReactNode;
   onFeedClick?: (feed: FeedPost) => void;
   toolbarConfig?: ToolbarConfig;
   className?: string;
 };
 
-function isRecordTypeValue(value: string): value is RecordTypeValue {
-  return RECORD_OPTION_ITEMS.some((option) => option.value === value);
-}
-
 export default function FeedList({
   feeds,
   sort,
   onSortChange,
+  sortItems,
+  tags = [],
+  onTagsChange,
   renderAction,
   onFeedClick,
   toolbarConfig,
@@ -44,25 +53,33 @@ export default function FeedList({
       <div className="flex justify-between px-6">
         <Select
           value={sort}
-          items={RECORD_OPTION_ITEMS}
-          placeholder={RECORD_OPTION_ITEMS[0].label}
+          items={sortItems}
+          placeholder={sortItems[0].label}
           onValueChange={(value) => {
-            if (typeof value === 'string' && isRecordTypeValue(value)) {
-              onSortChange(value);
+            if (typeof value === 'string') {
+              onSortChange(value as RecordTypeValue);
             }
           }}
         />
         <div className="flex gap-2">
-          {toolbarConfig?.tagFilter && (
-            <IconButton
-              aria-label="태그 필터"
-              icon={<Icon name="filter" />}
-              size="small"
-              variant="outline"
-            />
+          {toolbarConfig?.tagFilter && onTagsChange && (
+            <ReviewTagsSheet value={tags} onChange={onTagsChange}>
+              <IconButton
+                className={
+                  tags.length > 0
+                    ? 'border-semantic-accent-normal [&_svg]:size-5 [&_svg]:fill-semantic-accent-normal'
+                    : '[&_svg]:size-5'
+                }
+                aria-label="태그 필터"
+                icon={<Icon name="filter" />}
+                size="small"
+                variant="outline"
+              />
+            </ReviewTagsSheet>
           )}
           {toolbarConfig?.viewToggle && (
             <IconButton
+              className="[&_svg]:size-5"
               aria-label={
                 viewType === 'list'
                   ? '그리드 형식으로 게시글 보기'
@@ -82,6 +99,23 @@ export default function FeedList({
           )}
         </div>
       </div>
+      {tags.length > 0 && (
+        <div className="flex flex-wrap gap-2 px-6 pt-3">
+          {tags.map((tag) => (
+            <Chip
+              key={tag}
+              size="small"
+              variant="soft"
+              pressed
+              className="[&>svg]:size-2.5"
+              onClick={() => onTagsChange?.(tags.filter((t) => t !== tag))}
+            >
+              {PLACE_TAG_LABELS[tag]}
+              <Icon name="close" boxed={false} />
+            </Chip>
+          ))}
+        </div>
+      )}
       {viewType === 'list' ? (
         <div>
           {feeds.map((feed) => (

--- a/apps/web/src/widgets/feed-list/ui/FeedList.tsx
+++ b/apps/web/src/widgets/feed-list/ui/FeedList.tsx
@@ -108,11 +108,10 @@ export default function FeedList({
               size="small"
               variant="soft"
               pressed
-              className="[&>svg]:size-2.5"
               onClick={() => onTagsChange?.(tags.filter((t) => t !== tag))}
             >
               {PLACE_TAG_LABELS[tag]}
-              <Icon name="close" boxed={false} />
+              <Icon name="close" size={16} />
             </Chip>
           ))}
         </div>

--- a/apps/web/src/widgets/feed-list/ui/FeedList.tsx
+++ b/apps/web/src/widgets/feed-list/ui/FeedList.tsx
@@ -3,6 +3,7 @@
 import { type ReactNode } from 'react';
 
 import { Chip, Icon, IconButton, Select } from '@plog/ui';
+import { cn } from '@plog/utils';
 
 import { ReviewTagsSheet } from '@/features/select-review-tags';
 
@@ -49,7 +50,7 @@ export default function FeedList({
   const { viewType, toggleViewType } = useFeedViewType();
 
   return (
-    <section className={className}>
+    <section className={cn('w-full', className)}>
       <div className="flex justify-between px-6">
         <Select
           value={sort}

--- a/packages/ui/src/components/Badge/Badge.tsx
+++ b/packages/ui/src/components/Badge/Badge.tsx
@@ -5,96 +5,102 @@ import { cva } from 'class-variance-authority';
 
 import { type BadgeColor, type BadgeVariant } from './Badge.types';
 
-const badgeVariants = cva('caption-md rounded-sm py-0.5 px-1.5', {
-  variants: {
-    variant: {
-      solid: 'text-semantic-system-white',
-      soft: '',
-      outline: 'bg-semantic-system-white border',
+const badgeVariants = cva(
+  'inline-flex items-center h-5 px-1.5 caption-md rounded-sm',
+  {
+    variants: {
+      variant: {
+        solid: 'text-semantic-system-white',
+        soft: '',
+        outline: 'bg-semantic-system-white',
+      },
+      color: {
+        gray: '',
+        skyblue: '',
+        green: '',
+        yellow: '',
+        orange: '',
+      },
     },
-    color: {
-      gray: '',
-      skyblue: '',
-      green: '',
-      yellow: '',
-      orange: '',
-    },
+    compoundVariants: [
+      { variant: 'solid', color: 'gray', class: 'bg-semantic-object-normal' },
+      {
+        variant: 'solid',
+        color: 'skyblue',
+        class: 'bg-semantic-theme-sky-normal',
+      },
+      { variant: 'solid', color: 'green', class: 'bg-semantic-accent-normal' },
+      {
+        variant: 'solid',
+        color: 'yellow',
+        class:
+          'bg-semantic-theme-yellow-normal text-semantic-theme-yellow-bolder',
+      },
+      {
+        variant: 'solid',
+        color: 'orange',
+        class: 'bg-semantic-theme-orange-normal',
+      },
+      {
+        variant: 'soft',
+        color: 'gray',
+        class: 'bg-primitive-gray-40 text-semantic-object-normal',
+      },
+      {
+        variant: 'soft',
+        color: 'skyblue',
+        class: 'bg-semantic-theme-sky-subtle text-semantic-theme-sky-normal',
+      },
+      {
+        variant: 'soft',
+        color: 'green',
+        class: 'bg-semantic-accent-subtler text-semantic-accent-normal',
+      },
+      {
+        variant: 'soft',
+        color: 'yellow',
+        class:
+          'bg-semantic-theme-yellow-subtle text-semantic-theme-yellow-bold',
+      },
+      {
+        variant: 'soft',
+        color: 'orange',
+        class:
+          'bg-semantic-theme-orange-subtle text-semantic-theme-orange-normal',
+      },
+      {
+        variant: 'outline',
+        color: 'gray',
+        class:
+          'shadow-[inset_0_0_0_1px_var(--color-semantic-stroke-subtle)] text-semantic-object-normal',
+      },
+      {
+        variant: 'outline',
+        color: 'skyblue',
+        class:
+          'shadow-[inset_0_0_0_1px_var(--color-semantic-theme-sky-alternative)] text-semantic-theme-sky-normal',
+      },
+      {
+        variant: 'outline',
+        color: 'green',
+        class:
+          'shadow-[inset_0_0_0_1px_var(--color-semantic-accent-alternative)] text-semantic-accent-normal',
+      },
+      {
+        variant: 'outline',
+        color: 'yellow',
+        class:
+          'shadow-[inset_0_0_0_1px_var(--color-semantic-theme-yellow-normal)] text-semantic-theme-yellow-bold',
+      },
+      {
+        variant: 'outline',
+        color: 'orange',
+        class:
+          'shadow-[inset_0_0_0_1px_var(--color-semantic-theme-orange-alternative)] text-semantic-theme-orange-normal',
+      },
+    ],
   },
-  compoundVariants: [
-    { variant: 'solid', color: 'gray', class: 'bg-semantic-object-normal' },
-    {
-      variant: 'solid',
-      color: 'skyblue',
-      class: 'bg-semantic-theme-sky-normal',
-    },
-    { variant: 'solid', color: 'green', class: 'bg-semantic-accent-normal' },
-    {
-      variant: 'solid',
-      color: 'yellow',
-      class:
-        'bg-semantic-theme-yellow-normal text-semantic-theme-yellow-bolder',
-    },
-    {
-      variant: 'solid',
-      color: 'orange',
-      class: 'bg-semantic-theme-orange-normal',
-    },
-    {
-      variant: 'soft',
-      color: 'gray',
-      class: 'bg-primitive-gray-40 text-semantic-object-normal',
-    },
-    {
-      variant: 'soft',
-      color: 'skyblue',
-      class: 'bg-semantic-theme-sky-subtle text-semantic-theme-sky-normal',
-    },
-    {
-      variant: 'soft',
-      color: 'green',
-      class: 'bg-semantic-accent-subtler text-semantic-accent-normal',
-    },
-    {
-      variant: 'soft',
-      color: 'yellow',
-      class: 'bg-semantic-theme-yellow-subtle text-semantic-theme-yellow-bold',
-    },
-    {
-      variant: 'soft',
-      color: 'orange',
-      class:
-        'bg-semantic-theme-orange-subtle text-semantic-theme-orange-normal',
-    },
-    {
-      variant: 'outline',
-      color: 'gray',
-      class: 'border-semantic-stroke-subtle text-semantic-object-normal',
-    },
-    {
-      variant: 'outline',
-      color: 'skyblue',
-      class:
-        'border-semantic-theme-sky-alternative text-semantic-theme-sky-normal',
-    },
-    {
-      variant: 'outline',
-      color: 'green',
-      class: 'border-semantic-accent-alternative text-semantic-accent-normal',
-    },
-    {
-      variant: 'outline',
-      color: 'yellow',
-      class:
-        'border-semantic-theme-yellow-normal text-semantic-theme-yellow-bold',
-    },
-    {
-      variant: 'outline',
-      color: 'orange',
-      class:
-        'border-semantic-theme-orange-alternative text-semantic-theme-orange-normal',
-    },
-  ],
-});
+);
 
 type BadgeProps = ComponentPropsWithoutRef<'span'> & {
   variant: BadgeVariant;


### PR DESCRIPTION
## 📌 관련 이슈

- closes #99

## 📝 작업 내용

- [x] 마이페이지 기록 탭 API 연동
- [x] 마이페이지 북마크 탭 API 연동 
- [x] 북마크 토글 API 연동
- [x] `FeedList` `sortItems` required prop 전환, `tags`/`onTagsChange` 추가
- [x] `ReviewTagsSheet` 칩 렌더링 책임 제거
- [x] 상황별 `EmptyState` 공통 컴포넌트 분리
- [x] `getCategoryLabel` 유틸 추가

## 🔎 자세한 설명

### ✅ `FeedList` 정렬 옵션 책임 분리
기존에는 위젯 내부에 `RECORD_OPTION_ITEMS` 상수를 두고 기본값처럼 사용하고 있었는데, 화면마다 필요한 정렬 항목이나 사용하는 API 정렬 파라미터가 다릅니다.

`sortItems`를 required prop으로 추가하여 위젯은 렌더링과 인터랙션만 담당하도록 역할을 제한했습니다. 정렬 정책과 항목 구성은 호출처에서 결정하도록 했습니다.

### ✅ `ReviewTagsSheet` 선택 태그 칩 렌더링 제거

기존 `ReviewTagsSheet`는 태그 칩을 내부에서 직접 렌더링하고 있었는데, 실제 사용처마다 칩의 위치와 레이아웃 요구사항이 다릅니다.

그래서 `ReviewTagsSheet`의 책임을 태그 선택 시트 관리와 hidden input 처리로 제한하고, 칩 렌더링은 사용하는 곳에서 직접 담당하도록 변경했습니다.

### ✅ 북마크 토글 API 연동

북마크 추가는 즉시 실행하고, 제거할 때만 `dialog.confirm()`을 거치도록 했습니다. 상태 동기화는 `onMutate`에서 낙관적 업데이트로 즉각 반영하고, `onSuccess`에서 서버 응답값으로 최종 보정합니다.

마이페이지 쿼리는 `invalidateQueries`로 갱신하며, 에러 발생 시 snapshot 기반 롤백과 `toast` 처리까지 `features/toggle-bookmark` 내부에서 담당하도록 했습니다.

### ✅ 상황별 `EmptyState` 공통 컴포넌트 분리
자주 사용하는 5가지 상태의 Empty View를 `shared/ui` 레벨 컴포넌트로 분리했습니다.

컴포넌트 | 상황
-- | --
FetchErrorEmptyState | API / 네트워크 에러
RecordEmptyState | 기록 목록이 비어 있을 때
BookmarkEmptyState | 북마크 목록이 비어 있을 때
SearchEmptyState | 검색 결과 없음
PlaceSearchIdleState | 장소 검색 입력 전 대기 상태

각 컴포넌트는 `title`과 `graphic`을 기본 고정값으로 제공하고, `description`, `actions`, `className`은 optional prop으로 받아 필요한 경우 오버라이드할 수 있게 했습니다.

### ✅ 레이어별 코드 위치 결정
- `PostSortType` / `BookmarkSortType` → `entities/feed`
  - `focus`, `studyTime` 등의 값이 `FeedPost` 필드와 직접 대응되는 도메인 타입이라 feed 엔티티에 배치했습니다.

- 쿼리 훅 → `views/my/model`
  - `useMyPostsQuery`, `useMyBookmarksQuery`는 사용자 기반의 데이터를 다루기 때문에 user와 feed 엔티티가 함께 엮여 있다고 생각해서 특정 엔티티 레이어보다는 마이페이지 뷰에서 관리하도록 했습니다.

- `getCategoryLabel` → `entities/place/lib` 
  - `PLACE_CATEGORIES.find(...)` 로직을 유틸 함수로 추출했습니다. ~~현재는 임시로 `entities/place/lib`에 두었는데, 피드 엔티티에서 이를 참조하면서 엔티티 간 의존이 생긴 상태입니다. 이후 지도 API 연동 시 위치를 조정할 계획입니다.~~ → 753ae51 에서 `FeedList`에 장소 카테고리를 더이상 표시하지 않도록 하면서 해소되었습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

엔티티 레이어에 뷰 전용 API를 정의한 곳이 많이 보여서 이후 별도 리팩토링 진행 예정입니다~

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
