### PR TITLE
hotfix: serverExternalPackages 설정 추가

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,7 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
+  serverExternalPackages: ['jsdom', 'dompurify'],
   images: {
     remotePatterns: [
       {


### PR DESCRIPTION
## 📌 관련 이슈

- closes #107 

## 📝 작업 내용

- [x] Turbopack 환경에서 jsdom external 처리

## 🔎 자세한 설명

프로덕션 빌드 시 `jsdom` 번들링 과정 중 ESM/CJS 의존성 충돌이 발생했고, 이로 인해 `/signup` 페이지 접근 시 500 에러가 발생했습니다. `serverExternalPackages` 설정에서 `jsdom`, `dompurify`를 번들링 대상에서 제외했습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

@coderabbitai ignore

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
