### PR TITLE
chore: API 프록시 설정

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,6 +1,19 @@
 import type { NextConfig } from 'next';
 
+const SERVER_URL = (process.env.NEXT_PUBLIC_SERVER_URL ?? '').replace(
+  /\/$/,
+  '',
+);
+
 const nextConfig: NextConfig = {
+  async rewrites() {
+    return [
+      {
+        source: '/api/:path*',
+        destination: `${SERVER_URL}/api/:path*`,
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {

--- a/apps/web/src/shared/api/client-api.ts
+++ b/apps/web/src/shared/api/client-api.ts
@@ -1,4 +1,4 @@
-import { BASE_URL } from './constants';
+import { CLIENT_BASE_URL } from './constants';
 import { mergeHeaders, resolveBody } from './request.utils';
 import { parseApiResponse } from './response.utils';
 
@@ -9,7 +9,7 @@ async function request<T>(
   options?: RequestInit,
 ): Promise<T> {
   const bodyOptions = resolveBody(body);
-  const res = await fetch(`${BASE_URL}${endpoint}`, {
+  const res = await fetch(`${CLIENT_BASE_URL}${endpoint}`, {
     ...options,
     method,
     credentials: 'include',

--- a/apps/web/src/shared/api/constants.ts
+++ b/apps/web/src/shared/api/constants.ts
@@ -5,6 +5,8 @@ const SERVER_URL = (process.env.NEXT_PUBLIC_SERVER_URL ?? '').replace(
 
 export const BASE_URL = `${SERVER_URL}/api`;
 
+export const CLIENT_BASE_URL = '/api';
+
 export const KAKAO_LOGIN_URL = `${SERVER_URL}/oauth2/authorization/kakao`;
 
 export const API_ERROR_CODE = {


### PR DESCRIPTION
## 📌 관련 이슈

- closes #111 

## 📝 작업 내용

- [x] `next.config.ts` `rewrites` 프록시 설정 추가
- [x] `clientApi` base URL을 상대경로(/api)로 변경

## 🔎 자세한 설명

Vercel 배포 환경에서 API 요청 시 `credentials: 'include'` 요청이 CORS 정책에 의해 차단됩니다.  브라우저가 동일 오리진으로 요청하도록 Next.js `rewrites` 프록시 방식을 적용했습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

@coderabbitai ignore

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
