### PR TITLE
feat:  인증 만료 시 로그인 리다이렉트 처리

### DIFF
--- a/apps/web/src/shared/api/client-api.ts
+++ b/apps/web/src/shared/api/client-api.ts
@@ -1,6 +1,10 @@
+import { dialog } from '@/shared/lib/dialog';
+
 import { CLIENT_BASE_URL } from './constants';
 import { mergeHeaders, resolveBody } from './request.utils';
-import { parseApiResponse } from './response.utils';
+import { ApiResponseError, parseApiResponse } from './response.utils';
+
+let isRedirectingToLogin = false;
 
 async function request<T>(
   endpoint: string,
@@ -16,7 +20,21 @@ async function request<T>(
     headers: mergeHeaders(bodyOptions.headers, options?.headers),
     body: bodyOptions.body,
   });
-  return parseApiResponse<T>(res);
+
+  try {
+    return await parseApiResponse<T>(res);
+  } catch (error) {
+    if (
+      error instanceof ApiResponseError &&
+      error.errorCode === 'E401' &&
+      !isRedirectingToLogin
+    ) {
+      isRedirectingToLogin = true;
+      await dialog.alert('로그인이 필요합니다.');
+      window.location.href = '/login';
+    }
+    throw error;
+  }
 }
 
 export const clientApi = {

--- a/apps/web/src/shared/api/client-api.ts
+++ b/apps/web/src/shared/api/client-api.ts
@@ -30,7 +30,7 @@ async function request<T>(
       !isRedirectingToLogin
     ) {
       isRedirectingToLogin = true;
-      await dialog.alert('로그인이 필요합니다.');
+      await dialog.alert('로그인 후 이용할 수 있어요.');
       window.location.href = '/login';
     }
     throw error;


### PR DESCRIPTION
## 📌 관련 이슈

- closes #113 

## 📝 작업 내용

- [x] `clientApi`에서 `E401` 응답 감지 시 `/login`으로 리다이렉트 처리

## 🔎 자세한 설명

여러 API 요청이 동시에 `E401`을 반환할 수 있어 `isRedirectingToLogin` 플래그를 사용해 중복 처리를 방지했습니다. alert 호출 전 플래그를 먼저 설정하고, `window.location.href`로 페이지 이동시켜 모듈과 함께 플래그가 초기화되도록 했습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

@coderabbitai ignore

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
