### PR TITLE
hotfix: OAuth2 로그인 후 쿠키 저장을 위한 콜백 Route Handler 추가

### DIFF
--- a/apps/web/app/api/auth/callback/route.ts
+++ b/apps/web/app/api/auth/callback/route.ts
@@ -11,31 +11,25 @@ export async function GET(request: NextRequest) {
 
   const cookieStore = await cookies();
 
-  if (registerToken) {
-    cookieStore.set('registerToken', registerToken, {
+  const setCookie = (name: string, value: string) => {
+    cookieStore.set(name, value, {
       httpOnly: true,
       secure: true,
       sameSite: 'lax',
       path: '/',
     });
-    redirect('/signup');
+  };
+
+  if (registerToken?.trim()) {
+    setCookie('registerToken', registerToken);
+    return redirect('/signup');
   }
 
-  if (accessToken && refreshToken) {
-    cookieStore.set('accessToken', accessToken, {
-      httpOnly: true,
-      secure: true,
-      sameSite: 'lax',
-      path: '/',
-    });
-    cookieStore.set('refreshToken', refreshToken, {
-      httpOnly: true,
-      secure: true,
-      sameSite: 'lax',
-      path: '/',
-    });
-    redirect('/map');
+  if (accessToken?.trim() && refreshToken?.trim()) {
+    setCookie('accessToken', accessToken);
+    setCookie('refreshToken', refreshToken);
+    return redirect('/map');
   }
 
-  redirect('/login');
+  return redirect('/login');
 }

--- a/apps/web/app/api/auth/callback/route.ts
+++ b/apps/web/app/api/auth/callback/route.ts
@@ -1,0 +1,41 @@
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { type NextRequest } from 'next/server';
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+
+  const accessToken = searchParams.get('accessToken');
+  const refreshToken = searchParams.get('refreshToken');
+  const registerToken = searchParams.get('registerToken');
+
+  const cookieStore = await cookies();
+
+  if (registerToken) {
+    cookieStore.set('registerToken', registerToken, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+    });
+    redirect('/signup');
+  }
+
+  if (accessToken && refreshToken) {
+    cookieStore.set('accessToken', accessToken, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+    });
+    cookieStore.set('refreshToken', refreshToken, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax',
+      path: '/',
+    });
+    redirect('/map');
+  }
+
+  redirect('/login');
+}


### PR DESCRIPTION
## 📌 관련 이슈

- #116 

## 📝 작업 내용

- [x] `/api/auth/callback` Route Handler 추가

## 🔎 자세한 설명

CORS 정책을 우회하기 위해 프록시를 적용한 후 OAuth2 로그인 시 백엔드에서 설정한 쿠키가 프론트엔드 요청에 포함되지 않아 인증이 유지되지 않고 있습니다.

백엔드에서 토큰과 함께 `/api/auth/callback`으로 리다이렉트 하도록 변경하고, Route Handler에서 프론트엔드 도메인 기준으로 쿠키를 설정한 뒤 페이지를 이동하도록 했습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

@coderabbitai ignore

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
