### PR TITLE
feat: 상대 유저 프로필 API 연동

### DIFF
--- a/apps/web/src/entities/feed/api/client.ts
+++ b/apps/web/src/entities/feed/api/client.ts
@@ -1,0 +1,24 @@
+import { clientApi } from '@/shared/api/client-api';
+
+import {
+  type FeedProfilePosts,
+  type FeedProfileView,
+  type PostSortType,
+} from '../model/types';
+
+export const getFeedProfileView = (memberKey: string) => {
+  return clientApi.get<FeedProfileView>(
+    `/feed/profileView/${encodeURIComponent(memberKey)}`,
+  );
+};
+
+export const getFeedProfileViewPosts = (
+  memberKey: string,
+  sort: PostSortType = 'latest',
+) => {
+  const params = new URLSearchParams({ sort });
+
+  return clientApi.get<FeedProfilePosts>(
+    `/feed/profileView/${encodeURIComponent(memberKey)}/posts?${params}`,
+  );
+};

--- a/apps/web/src/entities/feed/index.ts
+++ b/apps/web/src/entities/feed/index.ts
@@ -1,3 +1,4 @@
+export { getFeedProfileView, getFeedProfileViewPosts } from './api/client';
 export {
   formatLikeCount,
   formatStudyDate,
@@ -16,11 +17,13 @@ export {
   type TagCategory,
   WorkConvenience,
 } from './model/place-tag';
-export { FEED_QUERY_KEY } from './model/query-keys';
+export { feedQueryKeys } from './model/query-keys';
 export type {
   BookmarkSortType,
   FeedPage,
   FeedPost,
+  FeedProfilePosts,
+  FeedProfileView,
   PostScope,
   PostSortType,
 } from './model/types';

--- a/apps/web/src/entities/feed/model/query-keys.ts
+++ b/apps/web/src/entities/feed/model/query-keys.ts
@@ -1,11 +1,11 @@
-import { PostSortType } from './types';
+import { type PostSortType } from './types';
 
 export const feedQueryKeys = {
   list: ['feed'] as const,
   detail: (postId: number) => ['feed', postId] as const,
   edit: (postId: number | null) => ['feed', 'edit', postId] as const,
-  profileView: (memberkey: string) =>
-    ['feed', 'profileView', memberkey] as const,
-  profileViewPosts: (memberkey: string, sort: PostSortType) =>
-    ['feed', 'profileView', memberkey, 'posts', sort] as const,
+  profileView: (memberKey: string) =>
+    ['feed', 'profileView', memberKey] as const,
+  profileViewPosts: (memberKey: string, sort: PostSortType) =>
+    ['feed', 'profileView', memberKey, 'posts', sort] as const,
 };

--- a/apps/web/src/entities/feed/model/query-keys.ts
+++ b/apps/web/src/entities/feed/model/query-keys.ts
@@ -1,1 +1,9 @@
-export const FEED_QUERY_KEY = ['feed'] as const;
+export const feedQueryKeys = {
+  list: ['feed'] as const,
+  detail: (postId: number) => ['feed', postId] as const,
+  edit: (postId: number | null) => ['feed', 'edit', postId] as const,
+  profileView: (memberkey: string) =>
+    ['feed', 'profileView', memberkey] as const,
+  profileViewPosts: (memberkey: string, sort: string) =>
+    ['feed', 'profileView', memberkey, 'posts', sort] as const,
+};

--- a/apps/web/src/entities/feed/model/query-keys.ts
+++ b/apps/web/src/entities/feed/model/query-keys.ts
@@ -1,9 +1,11 @@
+import { PostSortType } from './types';
+
 export const feedQueryKeys = {
   list: ['feed'] as const,
   detail: (postId: number) => ['feed', postId] as const,
   edit: (postId: number | null) => ['feed', 'edit', postId] as const,
   profileView: (memberkey: string) =>
     ['feed', 'profileView', memberkey] as const,
-  profileViewPosts: (memberkey: string, sort: string) =>
+  profileViewPosts: (memberkey: string, sort: PostSortType) =>
     ['feed', 'profileView', memberkey, 'posts', sort] as const,
 };

--- a/apps/web/src/entities/feed/model/types.ts
+++ b/apps/web/src/entities/feed/model/types.ts
@@ -2,6 +2,22 @@ import { type PlaceTagValue } from './place-tag';
 
 export type PostScope = 'PUBLIC' | 'PRIVATE';
 
+export type FeedProfileBadge = {
+  id: number;
+  name: string;
+  description: string;
+  imageUrl: string;
+  isAcquired: boolean;
+};
+
+export type FeedProfileMemberInfo = {
+  id?: number;
+  nickname: string;
+  profileImageUrl?: string;
+  introduction: string | null;
+  mainBadge: FeedProfileBadge | null;
+};
+
 export type FeedPost = {
   postId: number;
   name: string;
@@ -27,6 +43,15 @@ export type FeedPage = {
   items: FeedPost[];
   lastPostId: number | null;
   createAt: string | null;
+};
+
+export type FeedProfileView = {
+  memberInfo?: FeedProfileMemberInfo;
+  posts: FeedPost[];
+};
+
+export type FeedProfilePosts = {
+  posts: FeedPost[];
 };
 
 export type PostSortType = 'latest' | 'focus' | 'studyTime';

--- a/apps/web/src/entities/feed/model/types.ts
+++ b/apps/web/src/entities/feed/model/types.ts
@@ -37,6 +37,7 @@ export type FeedPost = {
   category?: string;
   address?: string;
   isPublic?: boolean;
+  isAuthor?: boolean;
 };
 
 export type FeedPage = {

--- a/apps/web/src/entities/feed/model/types.ts
+++ b/apps/web/src/entities/feed/model/types.ts
@@ -46,8 +46,7 @@ export type FeedPage = {
 };
 
 export type FeedProfileView = {
-  memberInfo?: FeedProfileMemberInfo;
-  posts: FeedPost[];
+  memberInfo: FeedProfileMemberInfo;
 };
 
 export type FeedProfilePosts = {

--- a/apps/web/src/entities/user/model/types.ts
+++ b/apps/web/src/entities/user/model/types.ts
@@ -63,7 +63,6 @@ export type UserProfileType = {
 };
 
 export type MypageData = {
-  memberKey?: string;
   nickname: string;
   profileImageUrl: string;
   introduction: string | null;

--- a/apps/web/src/entities/user/model/types.ts
+++ b/apps/web/src/entities/user/model/types.ts
@@ -63,6 +63,7 @@ export type UserProfileType = {
 };
 
 export type MypageData = {
+  memberKey?: string;
   nickname: string;
   profileImageUrl: string;
   introduction: string | null;

--- a/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
+++ b/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
@@ -7,7 +7,7 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 
-import { FEED_QUERY_KEY, type FeedPage } from '@/entities/feed';
+import { type FeedPage, feedQueryKeys } from '@/entities/feed';
 
 import { clientApi } from '@/shared/api/client-api';
 import { dialog } from '@/shared/lib/dialog';
@@ -41,12 +41,13 @@ export function useToggleBookmark() {
   const mutation = useMutation({
     mutationFn: postToggleBookmark,
     onMutate: async (postId) => {
-      await queryClient.cancelQueries({ queryKey: FEED_QUERY_KEY });
-      const snapshot =
-        queryClient.getQueryData<InfiniteData<FeedPage>>(FEED_QUERY_KEY);
+      await queryClient.cancelQueries({ queryKey: feedQueryKeys.list });
+      const snapshot = queryClient.getQueryData<InfiniteData<FeedPage>>(
+        feedQueryKeys.list,
+      );
 
       queryClient.setQueryData<InfiniteData<FeedPage>>(
-        FEED_QUERY_KEY,
+        feedQueryKeys.list,
         (prev) => {
           const current = prev?.pages
             .flatMap((p) => p.items)
@@ -63,7 +64,7 @@ export function useToggleBookmark() {
           .flatMap((p) => p.items)
           .find((post) => post.postId === postId);
         queryClient.setQueryData<InfiniteData<FeedPage>>(
-          FEED_QUERY_KEY,
+          feedQueryKeys.list,
           (prev) =>
             updateBookmarkInFeedCache(
               prev,
@@ -79,8 +80,9 @@ export function useToggleBookmark() {
       });
     },
     onSuccess: (res, postId) => {
-      queryClient.setQueryData<InfiniteData<FeedPage>>(FEED_QUERY_KEY, (prev) =>
-        updateBookmarkInFeedCache(prev, postId, res.isBookmarked),
+      queryClient.setQueryData<InfiniteData<FeedPage>>(
+        feedQueryKeys.list,
+        (prev) => updateBookmarkInFeedCache(prev, postId, res.isBookmarked),
       );
       queryClient.invalidateQueries({ queryKey: ['mypage'] });
       queryClient.invalidateQueries({ queryKey: ['map', 'count'] });

--- a/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
+++ b/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
@@ -7,7 +7,12 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 
-import { type FeedPage, feedQueryKeys } from '@/entities/feed';
+import {
+  type FeedPage,
+  type FeedProfilePosts,
+  feedQueryKeys,
+  type PostSortType,
+} from '@/entities/feed';
 
 import { clientApi } from '@/shared/api/client-api';
 import { dialog } from '@/shared/lib/dialog';
@@ -33,18 +38,57 @@ function updateBookmarkInFeedCache(
   };
 }
 
+function updateBookmarkInProfilePostsCache(
+  prev: FeedProfilePosts | undefined,
+  postId: number,
+  isBookmarked: boolean,
+): FeedProfilePosts | undefined {
+  if (!prev) return prev;
+  return {
+    ...prev,
+    posts: prev.posts.map((post) =>
+      post.postId === postId ? { ...post, bookMark: isBookmarked } : post,
+    ),
+  };
+}
+
+export type ProfilePostsBookmarkTarget = {
+  memberKey: string;
+  sort: PostSortType;
+};
+
+type ToggleBookmarkVariables = {
+  postId: number;
+  profilePostsTarget?: ProfilePostsBookmarkTarget;
+};
+
 export function useToggleBookmark() {
   const queryClient = useQueryClient();
 
   const { toast } = useToast();
 
   const mutation = useMutation({
-    mutationFn: postToggleBookmark,
-    onMutate: async (postId) => {
+    mutationFn: ({ postId }: ToggleBookmarkVariables) =>
+      postToggleBookmark(postId),
+    onMutate: async ({ postId, profilePostsTarget }) => {
+      const profilePostsQueryKey = profilePostsTarget
+        ? feedQueryKeys.profileViewPosts(
+            profilePostsTarget.memberKey,
+            profilePostsTarget.sort,
+          )
+        : undefined;
+
       await queryClient.cancelQueries({ queryKey: feedQueryKeys.list });
+      if (profilePostsQueryKey) {
+        await queryClient.cancelQueries({ queryKey: profilePostsQueryKey });
+      }
+
       const snapshot = queryClient.getQueryData<InfiniteData<FeedPage>>(
         feedQueryKeys.list,
       );
+      const profilePostsSnapshot = profilePostsQueryKey
+        ? queryClient.getQueryData<FeedProfilePosts>(profilePostsQueryKey)
+        : undefined;
 
       queryClient.setQueryData<InfiniteData<FeedPage>>(
         feedQueryKeys.list,
@@ -56,9 +100,23 @@ export function useToggleBookmark() {
         },
       );
 
-      return { snapshot };
+      if (profilePostsQueryKey) {
+        queryClient.setQueryData<FeedProfilePosts>(
+          profilePostsQueryKey,
+          (prev) => {
+            const current = prev?.posts.find((post) => post.postId === postId);
+            return updateBookmarkInProfilePostsCache(
+              prev,
+              postId,
+              !current?.bookMark,
+            );
+          },
+        );
+      }
+
+      return { profilePostsQueryKey, profilePostsSnapshot, snapshot };
     },
-    onError: (_err, postId, context) => {
+    onError: (_err, { postId }, context) => {
       if (context?.snapshot) {
         const original = context.snapshot.pages
           .flatMap((p) => p.items)
@@ -73,17 +131,30 @@ export function useToggleBookmark() {
             ),
         );
       }
+      if (context?.profilePostsQueryKey && context.profilePostsSnapshot) {
+        queryClient.setQueryData<FeedProfilePosts>(
+          context.profilePostsQueryKey,
+          context.profilePostsSnapshot,
+        );
+      }
       toast({
         id: 'bookmark-error',
         type: 'error',
         description: '북마크 처리 중 오류가 발생했어요.',
       });
     },
-    onSuccess: (res, postId) => {
+    onSuccess: (res, { postId }, context) => {
       queryClient.setQueryData<InfiniteData<FeedPage>>(
         feedQueryKeys.list,
         (prev) => updateBookmarkInFeedCache(prev, postId, res.isBookmarked),
       );
+      if (context.profilePostsQueryKey) {
+        queryClient.setQueryData<FeedProfilePosts>(
+          context.profilePostsQueryKey,
+          (prev) =>
+            updateBookmarkInProfilePostsCache(prev, postId, res.isBookmarked),
+        );
+      }
       queryClient.invalidateQueries({ queryKey: ['mypage'] });
       queryClient.invalidateQueries({ queryKey: ['map', 'count'] });
       queryClient.invalidateQueries({ queryKey: ['map', 'pins', 'bookmark'] });
@@ -96,6 +167,7 @@ export function useToggleBookmark() {
   const toggleBookmark = async (
     postId: number,
     isBookmarked: boolean,
+    profilePostsTarget?: ProfilePostsBookmarkTarget,
   ): Promise<boolean> => {
     if (isBookmarked) {
       const confirmed = await dialog.confirm({
@@ -106,7 +178,7 @@ export function useToggleBookmark() {
       if (!confirmed) return false;
     }
 
-    mutation.mutate(postId);
+    mutation.mutate({ postId, profilePostsTarget });
     return true;
   };
 

--- a/apps/web/src/features/toggle-bookmark/ui/BookmarkButton.tsx
+++ b/apps/web/src/features/toggle-bookmark/ui/BookmarkButton.tsx
@@ -5,17 +5,22 @@ import { type MouseEvent, useEffect, useState } from 'react';
 import { Icon } from '@plog/ui';
 import { cn } from '@plog/utils';
 
-import { useToggleBookmark } from '../model/use-toggle-bookmark';
+import {
+  type ProfilePostsBookmarkTarget,
+  useToggleBookmark,
+} from '../model/use-toggle-bookmark';
 
 type BookmarkButtonProps = {
   postId: number;
   isBookmarked: boolean;
+  profilePostsTarget?: ProfilePostsBookmarkTarget;
   className?: string;
 };
 
 export default function BookmarkButton({
   postId,
   isBookmarked,
+  profilePostsTarget,
   className,
 }: BookmarkButtonProps) {
   const [optimisticBookmarked, setOptimisticBookmarked] =
@@ -29,7 +34,11 @@ export default function BookmarkButton({
 
   const handleClick = async (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    const proceeded = await toggleBookmark(postId, optimisticBookmarked);
+    const proceeded = await toggleBookmark(
+      postId,
+      optimisticBookmarked,
+      profilePostsTarget,
+    );
     if (proceeded) setOptimisticBookmarked((prev) => !prev);
   };
 

--- a/apps/web/src/features/toggle-like/model/use-toggle-like.ts
+++ b/apps/web/src/features/toggle-like/model/use-toggle-like.ts
@@ -7,7 +7,7 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 
-import { FEED_QUERY_KEY, type FeedPage } from '@/entities/feed';
+import { type FeedPage, feedQueryKeys } from '@/entities/feed';
 
 import { clientApi } from '@/shared/api/client-api';
 
@@ -41,12 +41,13 @@ export function useToggleLike() {
   const mutation = useMutation({
     mutationFn: postToggleLike,
     onMutate: async (postId) => {
-      await queryClient.cancelQueries({ queryKey: FEED_QUERY_KEY });
-      const snapshot =
-        queryClient.getQueryData<InfiniteData<FeedPage>>(FEED_QUERY_KEY);
+      await queryClient.cancelQueries({ queryKey: feedQueryKeys.list });
+      const snapshot = queryClient.getQueryData<InfiniteData<FeedPage>>(
+        feedQueryKeys.list,
+      );
 
       queryClient.setQueryData<InfiniteData<FeedPage>>(
-        FEED_QUERY_KEY,
+        feedQueryKeys.list,
         (prev) => {
           const current = prev?.pages
             .flatMap((p) => p.items)
@@ -60,7 +61,7 @@ export function useToggleLike() {
     onError: (_err, _postId, context) => {
       if (context?.snapshot) {
         queryClient.setQueryData<InfiniteData<FeedPage>>(
-          FEED_QUERY_KEY,
+          feedQueryKeys.list,
           context.snapshot,
         );
       }
@@ -71,8 +72,9 @@ export function useToggleLike() {
       });
     },
     onSuccess: (res, postId) => {
-      queryClient.setQueryData<InfiniteData<FeedPage>>(FEED_QUERY_KEY, (prev) =>
-        updateLikeInFeedCache(prev, postId, res.isLiked),
+      queryClient.setQueryData<InfiniteData<FeedPage>>(
+        feedQueryKeys.list,
+        (prev) => updateLikeInFeedCache(prev, postId, res.isLiked),
       );
     },
   });

--- a/apps/web/src/views/feed-detail/model/types.ts
+++ b/apps/web/src/views/feed-detail/model/types.ts
@@ -1,5 +1,0 @@
-import { type FeedPost } from '@/entities/feed';
-
-export type FeedDetail = FeedPost & {
-  isAuthor: boolean;
-};

--- a/apps/web/src/views/feed-detail/model/use-delete-post-mutation.ts
+++ b/apps/web/src/views/feed-detail/model/use-delete-post-mutation.ts
@@ -9,7 +9,7 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 
-import { FEED_QUERY_KEY, type FeedPage } from '@/entities/feed';
+import { type FeedPage, feedQueryKeys } from '@/entities/feed';
 
 import { clientApi } from '@/shared/api/client-api';
 
@@ -41,18 +41,19 @@ export function useDeletePostMutation() {
     mutationFn: deletePost,
     onSuccess: (_data, postId) => {
       queryClient.removeQueries({
-        queryKey: [...FEED_QUERY_KEY, 'detail', postId],
+        queryKey: feedQueryKeys.detail(postId),
         exact: true,
       });
-      queryClient.setQueryData<InfiniteData<FeedPage>>(FEED_QUERY_KEY, (prev) =>
-        removePostFromFeedCache(prev, postId),
+      queryClient.setQueryData<InfiniteData<FeedPage>>(
+        feedQueryKeys.list,
+        (prev) => removePostFromFeedCache(prev, postId),
       );
 
       toast({ type: 'success', description: '게시글이 삭제되었어요.' });
       router.replace('/feed');
 
       void queryClient.invalidateQueries({
-        queryKey: FEED_QUERY_KEY,
+        queryKey: feedQueryKeys.list,
         exact: true,
       });
       void queryClient.invalidateQueries({ queryKey: ['mypage'] });

--- a/apps/web/src/views/feed-detail/model/use-feed-detail-query.ts
+++ b/apps/web/src/views/feed-detail/model/use-feed-detail-query.ts
@@ -2,7 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 
-import { FEED_QUERY_KEY } from '@/entities/feed';
+import { feedQueryKeys } from '@/entities/feed';
 
 import { clientApi } from '@/shared/api/client-api';
 
@@ -14,7 +14,7 @@ function getFeedDetail(postId: number) {
 
 export function useFeedDetailQuery(postId: number) {
   return useQuery({
-    queryKey: [...FEED_QUERY_KEY, 'detail', postId],
+    queryKey: feedQueryKeys.detail(postId),
     queryFn: () => getFeedDetail(postId),
     enabled: Number.isInteger(postId) && postId > 0,
   });

--- a/apps/web/src/views/feed-detail/model/use-feed-detail-query.ts
+++ b/apps/web/src/views/feed-detail/model/use-feed-detail-query.ts
@@ -2,14 +2,12 @@
 
 import { useQuery } from '@tanstack/react-query';
 
-import { feedQueryKeys } from '@/entities/feed';
+import { type FeedPost, feedQueryKeys } from '@/entities/feed';
 
 import { clientApi } from '@/shared/api/client-api';
 
-import { type FeedDetail } from './types';
-
 function getFeedDetail(postId: number) {
-  return clientApi.get<FeedDetail>(`/feed/${postId}`);
+  return clientApi.get<FeedPost>(`/feed/${postId}`);
 }
 
 export function useFeedDetailQuery(postId: number) {

--- a/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
+++ b/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
@@ -256,7 +256,7 @@ export default function FeedDetailCard({
                 type="button"
                 aria-label={`${post.name} 프로필 보기`}
                 onClick={handleProfileClick}
-                className="cursor-pointer rounded-full"
+                className="flex cursor-pointer items-center justify-center rounded-full"
               >
                 <Avatar
                   size="xsmall"

--- a/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
+++ b/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
@@ -389,16 +389,14 @@ export default function FeedDetailCard({
             <TagBadgeGroup tags={post.tags} />
           </div>
           <div className="mt-7 flex flex-col border-t border-semantic-object-subtler px-6 py-7">
-            <div className="flex items-center justify-between">
-              <span className="title-xs text-semantic-object-boldest">
-                {post.title}
-              </span>
-              <p className="caption-md text-semantic-object-subtle">
-                {formatStudyDate(post.createAt)}
-              </p>
-            </div>
-            <span className="body-sm text-semantic-object-normal">
+            <span className="title-xs mb-1 text-semantic-object-boldest">
+              {post.title}
+            </span>
+            <p className="body-sm mb-3 text-semantic-object-normal">
               {post.contents}
+            </p>
+            <span className="caption-md self-end text-semantic-object-subtle">
+              {formatStudyDate(post.createAt)}
             </span>
           </div>
         </div>

--- a/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
+++ b/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
@@ -237,7 +237,13 @@ export default function FeedDetailCard({
   }
 
   const hasMultipleImages = post.postImages.length > 1;
-  const isMyPost = post.isAuthor;
+  const isMyPost = post.isAuthor ?? false;
+
+  const handleProfileClick = () => {
+    if (!post.memberKey) return;
+    if (isMyPost) return;
+    router.push(`/feed/users/${encodeURIComponent(post.memberKey)}`);
+  };
 
   return (
     <>
@@ -246,9 +252,11 @@ export default function FeedDetailCard({
         <div className="flex items-center justify-between px-6 py-3">
           <div className="flex items-center gap-3">
             <Avatar
+              className="cursor-pointer"
               size="xsmall"
               src={post.profileImage}
               alt={`${post.name}의 프로필 이미지`}
+              onClick={handleProfileClick}
             />
             <div className="flex flex-col gap-1">
               <span className="label-lg text-semantic-object-boldest">

--- a/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
+++ b/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
@@ -238,10 +238,10 @@ export default function FeedDetailCard({
 
   const hasMultipleImages = post.postImages.length > 1;
   const isMyPost = post.isAuthor ?? false;
+  const isProfileClickable = Boolean(post.memberKey) && !isMyPost;
 
   const handleProfileClick = () => {
     if (!post.memberKey) return;
-    if (isMyPost) return;
     router.push(`/feed/users/${encodeURIComponent(post.memberKey)}`);
   };
 
@@ -251,13 +251,26 @@ export default function FeedDetailCard({
       <section className="relative pt-[var(--spacing-header)]">
         <div className="flex items-center justify-between px-6 py-3">
           <div className="flex items-center gap-3">
-            <Avatar
-              className="cursor-pointer"
-              size="xsmall"
-              src={post.profileImage}
-              alt={`${post.name}의 프로필 이미지`}
-              onClick={handleProfileClick}
-            />
+            {isProfileClickable ? (
+              <button
+                type="button"
+                aria-label={`${post.name} 프로필 보기`}
+                onClick={handleProfileClick}
+                className="cursor-pointer rounded-full"
+              >
+                <Avatar
+                  size="xsmall"
+                  src={post.profileImage}
+                  alt={`${post.name}의 프로필 이미지`}
+                />
+              </button>
+            ) : (
+              <Avatar
+                size="xsmall"
+                src={post.profileImage}
+                alt={`${post.name}의 프로필 이미지`}
+              />
+            )}
             <div className="flex flex-col gap-1">
               <span className="label-lg text-semantic-object-boldest">
                 {post.name}

--- a/apps/web/src/views/feed/model/use-infinite-feed-query.ts
+++ b/apps/web/src/views/feed/model/use-infinite-feed-query.ts
@@ -2,11 +2,9 @@
 
 import { useInfiniteQuery } from '@tanstack/react-query';
 
-import { FEED_QUERY_KEY, type FeedPage, type FeedPost } from '@/entities/feed';
+import { type FeedPage, type FeedPost, feedQueryKeys } from '@/entities/feed';
 
 import { clientApi } from '@/shared/api/client-api';
-
-export { FEED_QUERY_KEY };
 
 type FeedCursor = {
   lastPostId: number | null;
@@ -47,10 +45,10 @@ export function useInfiniteFeedQuery() {
     FeedPage,
     Error,
     { pages: FeedPage[]; pageParams: FeedCursor[] },
-    typeof FEED_QUERY_KEY,
+    typeof feedQueryKeys.list,
     FeedCursor
   >({
-    queryKey: FEED_QUERY_KEY,
+    queryKey: feedQueryKeys.list,
     queryFn: ({ pageParam }) => getFeedPage(pageParam),
     initialPageParam: {
       lastPostId: 0,

--- a/apps/web/src/views/feed/ui/FeedCard.tsx
+++ b/apps/web/src/views/feed/ui/FeedCard.tsx
@@ -88,7 +88,7 @@ export default function FeedCard({ post, isLast }: FeedCardProps) {
     //Todo: 메인피드조회 isAuthor데이터 추가되면  event.stopPropagation(); 로직 필요
 
     if (!post.memberKey) return;
-
+    if (post.isAuthor) return;
     router.push(`/feed/users/${encodeURIComponent(post.memberKey)}`);
   };
 

--- a/apps/web/src/views/feed/ui/FeedCard.tsx
+++ b/apps/web/src/views/feed/ui/FeedCard.tsx
@@ -83,7 +83,7 @@ export default function FeedCard({ post, isLast }: FeedCardProps) {
       isEnd: swiper.isEnd,
     });
   };
-
+  const isProfileClickable = Boolean(post.memberKey) && !post.isAuthor;
   const handleProfileClick = () => {
     if (!post.memberKey) return;
     if (post.isAuthor) return;
@@ -93,13 +93,26 @@ export default function FeedCard({ post, isLast }: FeedCardProps) {
   return (
     <div className={isLast ? '' : 'mb-13.5'}>
       <div className="flex items-center gap-3 px-6 py-3">
-        <Avatar
-          size="xsmall"
-          src={post.profileImage}
-          alt={`${post.name}의 프로필 이미지`}
-          className="cursor-pointer"
-          onClick={handleProfileClick}
-        />
+        {isProfileClickable ? (
+          <button
+            type="button"
+            aria-label={`${post.name} 프로필 보기`}
+            onClick={handleProfileClick}
+            className="cursor-pointer rounded-full"
+          >
+            <Avatar
+              size="xsmall"
+              src={post.profileImage}
+              alt={`${post.name}의 프로필 이미지`}
+            />
+          </button>
+        ) : (
+          <Avatar
+            size="xsmall"
+            src={post.profileImage}
+            alt={`${post.name}의 프로필 이미지`}
+          />
+        )}
         <div className="flex flex-col gap-1">
           <span className="label-lg text-semantic-object-boldest">
             {post.name}

--- a/apps/web/src/views/feed/ui/FeedCard.tsx
+++ b/apps/web/src/views/feed/ui/FeedCard.tsx
@@ -101,7 +101,7 @@ export default function FeedCard({ post, isLast }: FeedCardProps) {
             type="button"
             aria-label={`${post.name} 프로필 보기`}
             onClick={handleProfileClick}
-            className="cursor-pointer rounded-full"
+            className="flex cursor-pointer items-center justify-center rounded-full"
           >
             <Avatar
               size="xsmall"

--- a/apps/web/src/views/feed/ui/FeedCard.tsx
+++ b/apps/web/src/views/feed/ui/FeedCard.tsx
@@ -4,6 +4,7 @@ import { useLayoutEffect, useRef, useState } from 'react';
 
 import Image from 'next/image';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 
 import { Avatar, Carousel, Icon } from '@plog/ui';
 import { cn } from '@plog/utils';
@@ -74,13 +75,21 @@ export default function FeedCard({ post, isLast }: FeedCardProps) {
     isBeginning: true,
     isEnd: post.postImages.length <= 1,
   });
-
+  const router = useRouter();
   const hasMultipleImages = post.postImages.length > 1;
   const updateCarouselEdgeState = (swiper: FeedCarouselController) => {
     setCarouselState({
       isBeginning: swiper.isBeginning,
       isEnd: swiper.isEnd,
     });
+  };
+
+  const handleProfileClick = () => {
+    //Todo: 메인피드조회 isAuthor데이터 추가되면  event.stopPropagation(); 로직 필요
+
+    if (!post.memberKey) return;
+
+    router.push(`/feed/users/${encodeURIComponent(post.memberKey)}`);
   };
 
   return (
@@ -90,6 +99,7 @@ export default function FeedCard({ post, isLast }: FeedCardProps) {
           size="xsmall"
           src={post.profileImage}
           alt={`${post.name}의 프로필 이미지`}
+          onClick={handleProfileClick}
         />
         <div className="flex flex-col gap-1">
           <span className="label-lg text-semantic-object-boldest">

--- a/apps/web/src/views/feed/ui/FeedCard.tsx
+++ b/apps/web/src/views/feed/ui/FeedCard.tsx
@@ -76,14 +76,17 @@ export default function FeedCard({ post, isLast }: FeedCardProps) {
     isEnd: post.postImages.length <= 1,
   });
   const router = useRouter();
+
   const hasMultipleImages = post.postImages.length > 1;
+  const isProfileClickable = Boolean(post.memberKey) && !post.isAuthor;
+
   const updateCarouselEdgeState = (swiper: FeedCarouselController) => {
     setCarouselState({
       isBeginning: swiper.isBeginning,
       isEnd: swiper.isEnd,
     });
   };
-  const isProfileClickable = Boolean(post.memberKey) && !post.isAuthor;
+
   const handleProfileClick = () => {
     if (!post.memberKey) return;
     if (post.isAuthor) return;

--- a/apps/web/src/views/feed/ui/FeedCard.tsx
+++ b/apps/web/src/views/feed/ui/FeedCard.tsx
@@ -85,8 +85,6 @@ export default function FeedCard({ post, isLast }: FeedCardProps) {
   };
 
   const handleProfileClick = () => {
-    //Todo: 메인피드조회 isAuthor데이터 추가되면  event.stopPropagation(); 로직 필요
-
     if (!post.memberKey) return;
     if (post.isAuthor) return;
     router.push(`/feed/users/${encodeURIComponent(post.memberKey)}`);
@@ -99,6 +97,7 @@ export default function FeedCard({ post, isLast }: FeedCardProps) {
           size="xsmall"
           src={post.profileImage}
           alt={`${post.name}의 프로필 이미지`}
+          className="cursor-pointer"
           onClick={handleProfileClick}
         />
         <div className="flex flex-col gap-1">

--- a/apps/web/src/views/log/model/use-create-log-mutation.ts
+++ b/apps/web/src/views/log/model/use-create-log-mutation.ts
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useToast } from '@plog/ui';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { FEED_QUERY_KEY } from '@/entities/feed';
+import { feedQueryKeys } from '@/entities/feed';
 
 import { clientApi } from '@/shared/api/client-api';
 import { createMultipartRequest } from '@/shared/api/create-multipart-request';
@@ -36,7 +36,7 @@ export function useCreateLogMutation({
       createPost(mapCreateLogForm(values), getNewPhotoFiles(values)),
     onSuccess: async () => {
       onSuccess?.();
-      await queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY });
+      await queryClient.invalidateQueries({ queryKey: feedQueryKeys.list });
       toast({ type: 'success', description: '기록이 등록되었어요.' });
       router.replace('/feed');
     },

--- a/apps/web/src/views/log/model/use-edit-log-query.ts
+++ b/apps/web/src/views/log/model/use-edit-log-query.ts
@@ -2,7 +2,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 
-import { FEED_QUERY_KEY } from '@/entities/feed';
+import { feedQueryKeys } from '@/entities/feed';
 
 import { clientApi } from '@/shared/api/client-api';
 
@@ -14,7 +14,7 @@ function getPostForEdit(postId: number) {
 
 export function useEditLogQuery(postId: number | null) {
   return useQuery({
-    queryKey: [...FEED_QUERY_KEY, 'edit', postId],
+    queryKey: feedQueryKeys.edit(postId),
     queryFn: () => getPostForEdit(postId as number),
     enabled: postId !== null && Number.isFinite(postId),
   });

--- a/apps/web/src/views/log/model/use-update-log-mutation.ts
+++ b/apps/web/src/views/log/model/use-update-log-mutation.ts
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import { useToast } from '@plog/ui';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
-import { FEED_QUERY_KEY } from '@/entities/feed';
+import { feedQueryKeys } from '@/entities/feed';
 
 import { clientApi } from '@/shared/api/client-api';
 import { createMultipartRequest } from '@/shared/api/create-multipart-request';
@@ -55,7 +55,7 @@ export function useUpdateLogMutation({
     },
     onSuccess: async () => {
       onSuccess?.();
-      await queryClient.invalidateQueries({ queryKey: FEED_QUERY_KEY });
+      await queryClient.invalidateQueries({ queryKey: feedQueryKeys.list });
       toast({ type: 'success', description: '기록이 수정되었어요.' });
       if (postId !== null) router.replace(`/feed/${postId}`);
     },

--- a/apps/web/src/views/users-detail/model/use-feed-profile-posts-query.ts
+++ b/apps/web/src/views/users-detail/model/use-feed-profile-posts-query.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 import {
   feedQueryKeys,
@@ -18,6 +18,7 @@ export function useFeedProfilePostsQuery(
     queryKey: feedQueryKeys.profileViewPosts(selectedMember, sort),
     queryFn: () => getFeedProfileViewPosts(selectedMember, sort),
     enabled: selectedMember.length > 0,
+    placeholderData: keepPreviousData,
     select: (data) => data.posts,
   });
 }

--- a/apps/web/src/views/users-detail/model/use-feed-profile-posts-query.ts
+++ b/apps/web/src/views/users-detail/model/use-feed-profile-posts-query.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import {
+  feedQueryKeys,
+  getFeedProfileViewPosts,
+  type PostSortType,
+} from '@/entities/feed';
+
+export function useFeedProfilePostsQuery(
+  memberKey: string,
+  sort: PostSortType,
+) {
+  const selectedMember = memberKey.trim();
+
+  return useQuery({
+    queryKey: feedQueryKeys.profileViewPosts(selectedMember, sort),
+    queryFn: () => getFeedProfileViewPosts(selectedMember, sort),
+    enabled: selectedMember.length > 0,
+    select: (data) => data.posts,
+  });
+}

--- a/apps/web/src/views/users-detail/model/use-feed-profile-view-query.ts
+++ b/apps/web/src/views/users-detail/model/use-feed-profile-view-query.ts
@@ -1,0 +1,15 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { feedQueryKeys, getFeedProfileView } from '@/entities/feed';
+
+export function useFeedProfileViewQuery(memberKey: string) {
+  const selectedMember = memberKey.trim();
+
+  return useQuery({
+    queryKey: feedQueryKeys.profileView(selectedMember),
+    queryFn: () => getFeedProfileView(selectedMember),
+    enabled: selectedMember.length > 0,
+  });
+}

--- a/apps/web/src/views/users-detail/ui/UserFeedSection.tsx
+++ b/apps/web/src/views/users-detail/ui/UserFeedSection.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
+import { Spinner } from '@plog/ui';
 import { cn } from '@plog/utils';
 
 import {
@@ -50,20 +51,10 @@ export default function UserFeedSection({ userId }: { userId: string }) {
     );
   };
 
-  if (isPending) return null;
-
   if (isError) {
     return (
       <section className="flex flex-1 items-center justify-center pt-3">
         <FetchErrorEmptyState onRetry={refetch} />
-      </section>
-    );
-  }
-
-  if (feeds.length === 0) {
-    return (
-      <section className="flex flex-1 items-center justify-center pt-3">
-        <RecordEmptyState />
       </section>
     );
   }
@@ -82,10 +73,14 @@ export default function UserFeedSection({ userId }: { userId: string }) {
         toolbarConfig={{ viewToggle: true }}
         emptyView={
           <div className="flex flex-1 items-center justify-center">
-            <RecordEmptyState
-              title="일치하는 정보가 없어요"
-              description="다른 정렬 기준을 선택해 보세요."
-            />
+            {isPending ? (
+              <Spinner size="large" />
+            ) : (
+              <RecordEmptyState
+                title="일치하는 정보가 없어요"
+                description="다른 정렬 기준을 선택해 보세요."
+              />
+            )}
           </div>
         }
         renderAction={(feed, viewType: FeedViewType) => {

--- a/apps/web/src/views/users-detail/ui/UserFeedSection.tsx
+++ b/apps/web/src/views/users-detail/ui/UserFeedSection.tsx
@@ -84,7 +84,7 @@ export default function UserFeedSection({ userId }: { userId: string }) {
           <div className="flex flex-1 items-center justify-center">
             <RecordEmptyState
               title="일치하는 정보가 없어요"
-              description="다른 태그를 선택해 보세요."
+              description="다른 정렬 기준을 선택해 보세요."
             />
           </div>
         }
@@ -94,6 +94,7 @@ export default function UserFeedSection({ userId }: { userId: string }) {
             <BookmarkButton
               postId={feed.postId}
               isBookmarked={isBookmarked}
+              profilePostsTarget={{ memberKey: userId, sort }}
               className={cn(
                 viewType === 'grid' &&
                   (isBookmarked

--- a/apps/web/src/views/users-detail/ui/UserFeedSection.tsx
+++ b/apps/web/src/views/users-detail/ui/UserFeedSection.tsx
@@ -4,7 +4,6 @@ import { useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-import { Spinner } from '@plog/ui';
 import { cn } from '@plog/utils';
 
 import {
@@ -51,6 +50,8 @@ export default function UserFeedSection({ userId }: { userId: string }) {
     );
   };
 
+  if (isPending) return null;
+
   if (isError) {
     return (
       <section className="flex flex-1 items-center justify-center pt-3">
@@ -73,14 +74,7 @@ export default function UserFeedSection({ userId }: { userId: string }) {
         toolbarConfig={{ viewToggle: true }}
         emptyView={
           <div className="flex flex-1 items-center justify-center">
-            {isPending ? (
-              <Spinner size="large" />
-            ) : (
-              <RecordEmptyState
-                title="일치하는 정보가 없어요"
-                description="다른 정렬 기준을 선택해 보세요."
-              />
-            )}
+            <RecordEmptyState description="" />
           </div>
         }
         renderAction={(feed, viewType: FeedViewType) => {

--- a/apps/web/src/views/users-detail/ui/UserFeedSection.tsx
+++ b/apps/web/src/views/users-detail/ui/UserFeedSection.tsx
@@ -1,34 +1,48 @@
 'use client';
 
-// import { useMemo, useState } from 'react';
+import { useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-// import { cn } from '@plog/utils';
-//
-// import {
-//   FeedList,
-//   type FeedViewType,
-//   type RecordTypeValue,
-// } from '@/widgets/feed-list';
-//
-// import { BookmarkButton } from '@/features/toggle-bookmark';
-import { type FeedPost } from '@/entities/feed';
+import { cn } from '@plog/utils';
+
+import {
+  FeedList,
+  type FeedViewType,
+  type RecordTypeValue,
+} from '@/widgets/feed-list';
+
+import { BookmarkButton } from '@/features/toggle-bookmark';
+
+import { type FeedPost, type PostSortType } from '@/entities/feed';
 
 import { useScrollToTop } from '@/shared/lib/scroll-to-top';
-import { ScrollToTopButton } from '@/shared/ui';
+import {
+  FetchErrorEmptyState,
+  RecordEmptyState,
+  ScrollToTopButton,
+} from '@/shared/ui';
+
+import { useFeedProfilePostsQuery } from '../model/use-feed-profile-posts-query';
+
+const SORT_ITEMS: { value: PostSortType; label: string }[] = [
+  { value: 'latest', label: '최신순' },
+  { value: 'focus', label: '집중도순' },
+  { value: 'studyTime', label: '작업시간순' },
+];
 
 export default function UserFeedSection({ userId }: { userId: string }) {
   const router = useRouter();
 
   const { topRef, visible: scrollToTopVisible } = useScrollToTop();
+  const [sort, setSort] = useState<PostSortType>('latest');
 
-  // const [sort, setSort] = useState<RecordTypeValue>('latest');
-
-  // const sortedFeeds = useMemo(
-  //   () => sortFeeds(userFeeds, sort),
-  //   [userFeeds, sort],
-  // );
+  const {
+    data: feeds = [],
+    isPending,
+    isError,
+    refetch,
+  } = useFeedProfilePostsQuery(userId, sort);
 
   const handleFeedClick = (feed: FeedPost) => {
     router.push(
@@ -36,32 +50,60 @@ export default function UserFeedSection({ userId }: { userId: string }) {
     );
   };
 
+  if (isPending) return null;
+
+  if (isError) {
+    return (
+      <section className="flex flex-1 items-center justify-center pt-3">
+        <FetchErrorEmptyState onRetry={refetch} />
+      </section>
+    );
+  }
+
+  if (feeds.length === 0) {
+    return (
+      <section className="flex flex-1 items-center justify-center pt-3">
+        <RecordEmptyState />
+      </section>
+    );
+  }
+
   return (
     <section className="pt-3">
       <div ref={topRef} aria-hidden="true" className="h-px w-full" />
-      {/*<FeedList*/}
-      {/*  feeds={sortedFeeds}*/}
-      {/*  sort={sort}*/}
-      {/*  onSortChange={setSort}*/}
-      {/*  sortItems={SORT_ITEMS}*/}
-      {/*  onFeedClick={handleFeedClick}*/}
-      {/*  toolbarConfig={{ viewToggle: true }}*/}
-      {/*  renderAction={(feed, viewType: FeedViewType) => {*/}
-      {/*    const isBookmarked = feed.bookMark;*/}
-      {/*    return (*/}
-      {/*      <BookmarkButton*/}
-      {/*        postId={feed.postId}*/}
-      {/*        isBookmarked={isBookmarked}*/}
-      {/*        className={cn(*/}
-      {/*          viewType === 'grid' &&*/}
-      {/*            (isBookmarked*/}
-      {/*              ? '[&_path]:fill-semantic-accent-normal'*/}
-      {/*              : '[&_path]:fill-semantic-object-subtler'),*/}
-      {/*        )}*/}
-      {/*      />*/}
-      {/*    );*/}
-      {/*  }}*/}
-      {/*/>*/}
+      <FeedList
+        feeds={feeds}
+        sort={sort}
+        onSortChange={(value: RecordTypeValue) =>
+          setSort(value as PostSortType)
+        }
+        sortItems={SORT_ITEMS}
+        onFeedClick={handleFeedClick}
+        toolbarConfig={{ viewToggle: true }}
+        emptyView={
+          <div className="flex flex-1 items-center justify-center">
+            <RecordEmptyState
+              title="일치하는 정보가 없어요"
+              description="다른 태그를 선택해 보세요."
+            />
+          </div>
+        }
+        renderAction={(feed, viewType: FeedViewType) => {
+          const isBookmarked = feed.bookMark;
+          return (
+            <BookmarkButton
+              postId={feed.postId}
+              isBookmarked={isBookmarked}
+              className={cn(
+                viewType === 'grid' &&
+                  (isBookmarked
+                    ? 'text-semantic-accent-normal'
+                    : 'text-semantic-object-subtle'),
+              )}
+            />
+          );
+        }}
+      />
       <ScrollToTopButton visible={scrollToTopVisible} />
     </section>
   );

--- a/apps/web/src/views/users-detail/ui/UserProfileSection.tsx
+++ b/apps/web/src/views/users-detail/ui/UserProfileSection.tsx
@@ -2,16 +2,29 @@
 
 import { UserProfile, type UserProfileType } from '@/entities/user';
 
-// TODO: API 연동 시 /api/feed/profileView/{memberKey} 응답의 memberInfo로 교체
-const MOCK_PROFILE: UserProfileType = {
-  id: 4,
-  nickname: 'zl존하민ㅋ',
-  introduction:
-    '글자수백자글자수백자글자수백자글자수백자글자수백자글자수백자글자수백자글자수백자글자수백자글자수백자글자수백자글자수백자글자수백자글자수백자글자수백자글자수백자글자수백자글자수백자',
-  mainBadge: null,
-};
+import { useFeedProfileViewQuery } from '../model/use-feed-profile-view-query';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function getProfileFromFeedView(
+  data: ReturnType<typeof useFeedProfileViewQuery>['data'],
+): UserProfileType | null {
+  if (data?.memberInfo) return data.memberInfo;
+
+  const firstPost = data?.posts[0];
+  if (!firstPost) return null;
+
+  return {
+    nickname: firstPost.name,
+    profileImageUrl: firstPost.profileImage,
+    introduction: null,
+    mainBadge: null,
+  };
+}
+
 export default function UserProfileSection({ userId }: { userId: string }) {
-  return <UserProfile profile={MOCK_PROFILE} />;
+  const { data, isPending, isError } = useFeedProfileViewQuery(userId);
+  const profile = getProfileFromFeedView(data);
+
+  if (isPending || isError || !profile) return null;
+
+  return <UserProfile profile={profile} />;
 }

--- a/apps/web/src/views/users-detail/ui/UserProfileSection.tsx
+++ b/apps/web/src/views/users-detail/ui/UserProfileSection.tsx
@@ -1,30 +1,13 @@
 'use client';
 
-import { UserProfile, type UserProfileType } from '@/entities/user';
+import { UserProfile } from '@/entities/user';
 
 import { useFeedProfileViewQuery } from '../model/use-feed-profile-view-query';
 
-function getProfileFromFeedView(
-  data: ReturnType<typeof useFeedProfileViewQuery>['data'],
-): UserProfileType | null {
-  if (data?.memberInfo) return data.memberInfo;
-
-  const firstPost = data?.posts[0];
-  if (!firstPost) return null;
-
-  return {
-    nickname: firstPost.name,
-    profileImageUrl: firstPost.profileImage,
-    introduction: null,
-    mainBadge: null,
-  };
-}
-
 export default function UserProfileSection({ userId }: { userId: string }) {
   const { data, isPending, isError } = useFeedProfileViewQuery(userId);
-  const profile = getProfileFromFeedView(data);
 
-  if (isPending || isError || !profile) return null;
+  if (isPending || isError || !data?.memberInfo) return null;
 
-  return <UserProfile profile={profile} />;
+  return <UserProfile profile={data.memberInfo} />;
 }


### PR DESCRIPTION
## 📌 관련 이슈

- closes #118 

## 📝 작업 내용

- [x] 상대 유저 프로필 API 연동
- [x] 상대 유저 작성 게시글 API 연동 
- [x] 기존의 흩어진 feed 쿼리키 `query-factory-key`패턴으로 리팩토링

## 🔎 자세한 설명

### ✅ 상대 유저 프로필 API 연동
> `/feed/profileView/{memberKey} API`를 연동해 상대 유저 프로필 정보를 조회하도록 구현했습니다.
피드 메인에서 유저 프로필 이미지를 클릭하면 해당 게시글 작성자의 `memberKey`를 기반으로 상대 유저 프로필 페이지로 이동하도록 연결했습니다. 본인 게시글의 프로필 이미지를 클릭한 경우에는 상대 유저 프로필 페이지로 이동하지 않도록 예외 처리했습니다.

### ✅ 상대 유저 작성 게시글 API 연동
>`/feed/profileView/{memberKey}/posts API`를 연동해 상대 유저가 작성한 게시글 목록을 조회하도록 구현했습니다.
정렬 조건(`latest, focus, studyTime`) 변경 시 서버 API를 다시 호출하도록 `쿼리키에 sort`값을 포함했습니다.
API 스펙에 맞춰 태그 필터링 UI는 제거하고, 작성 게시글 목록은 서버 정렬 결과를 그대로 렌더링하도록 정리했습니다.

### ✅ 기존의 흩어진 feed 쿼리키 `query-factory-key` 패턴으로 리팩토링
>기존에 `FEED_QUERY_KEY`, 개별 `profile query key` 함수 등으로 흩어져 있던 `feed` 관련 쿼리키를 `feedQueryKeys` 객체로 통합했습니다. 피드 목록, 상세 조회, 수정 조회, 상대 유저 프로필 조회, 상대 유저 게시글 조회 쿼리키를 한 곳에서 관리하도록 정리했습니다.
좋아요, 북마크, 게시글 작성/수정/삭제 등 캐시 갱신 로직도 feedQueryKeys를 사용하도록 변경했습니다.

## 🖼️ 스크린샷

> UI 변경이 있다면 Before / After 스크린샷을 첨부해 주세요.

## 💬 리뷰어에게

> 리뷰 시 집중적으로 봐줬으면 하는 부분이나 참고할 내용을 적어주세요.

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
