### PR TITLE
hotfix: 게시글 생성 시 발생하는 버그 수정 + 게시글 수정하기 버그 수정

### DIFF
--- a/apps/web/app/(with-tab)/log/page.tsx
+++ b/apps/web/app/(with-tab)/log/page.tsx
@@ -3,11 +3,14 @@ import { CreateLogPage } from '@/views/log';
 type LogPageProps = {
   searchParams: Promise<{
     postId?: string;
+    restoreDraft?: string;
   }>;
 };
 
 export default async function LogPage({ searchParams }: LogPageProps) {
-  const { postId } = await searchParams;
+  const { postId, restoreDraft } = await searchParams;
 
-  return <CreateLogPage editPostId={postId} />;
+  return (
+    <CreateLogPage editPostId={postId} restoreDraft={restoreDraft === '1'} />
+  );
 }

--- a/apps/web/app/(with-tab)/log/page.tsx
+++ b/apps/web/app/(with-tab)/log/page.tsx
@@ -2,15 +2,21 @@ import { CreateLogPage } from '@/views/log';
 
 type LogPageProps = {
   searchParams: Promise<{
-    postId?: string;
-    restoreDraft?: string;
+    postId?: string | string[];
+    restoreDraft?: string | string[];
   }>;
 };
 
 export default async function LogPage({ searchParams }: LogPageProps) {
   const { postId, restoreDraft } = await searchParams;
+  const normalizedPostId = typeof postId === 'string' ? postId : postId?.[0];
+  const normalizedRestoreDraft =
+    typeof restoreDraft === 'string' ? restoreDraft : restoreDraft?.[0];
 
   return (
-    <CreateLogPage editPostId={postId} restoreDraft={restoreDraft === '1'} />
+    <CreateLogPage
+      editPostId={normalizedPostId}
+      restoreDraft={normalizedRestoreDraft === '1'}
+    />
   );
 }

--- a/apps/web/app/(with-tab)/log/place-search/page.tsx
+++ b/apps/web/app/(with-tab)/log/place-search/page.tsx
@@ -1,3 +1,15 @@
 import { SearchPlacePage } from '@/views/log-place-search';
 
-export default SearchPlacePage;
+type LogPlaceSearchPageProps = {
+  searchParams: Promise<{
+    returnTo?: string;
+  }>;
+};
+
+export default async function LogPlaceSearchPage({
+  searchParams,
+}: LogPlaceSearchPageProps) {
+  const { returnTo } = await searchParams;
+
+  return <SearchPlacePage returnTo={returnTo} />;
+}

--- a/apps/web/app/(with-tab)/log/place-search/page.tsx
+++ b/apps/web/app/(with-tab)/log/place-search/page.tsx
@@ -2,7 +2,7 @@ import { SearchPlacePage } from '@/views/log-place-search';
 
 type LogPlaceSearchPageProps = {
   searchParams: Promise<{
-    returnTo?: string;
+    returnTo?: string | string[];
   }>;
 };
 
@@ -10,6 +10,8 @@ export default async function LogPlaceSearchPage({
   searchParams,
 }: LogPlaceSearchPageProps) {
   const { returnTo } = await searchParams;
+  const normalizedReturnTo =
+    typeof returnTo === 'string' ? returnTo : returnTo?.[0];
 
-  return <SearchPlacePage returnTo={returnTo} />;
+  return <SearchPlacePage returnTo={normalizedReturnTo} />;
 }

--- a/apps/web/src/features/create-log/model/use-create-log-store.ts
+++ b/apps/web/src/features/create-log/model/use-create-log-store.ts
@@ -51,11 +51,11 @@ export const useCreateLogStore = create(
     combine(initialState, (set) => ({
       setValues: (
         values: Partial<CreateLogStoredValues>,
-        draftPostId?: number | null,
+        draftPostId: number | null,
       ) =>
         set((state) => ({
           values: { ...state.values, ...values },
-          ...(draftPostId !== undefined ? { draftPostId } : {}),
+          ...(draftPostId !== undefined ? { draftPostId } : draftPostId),
         })),
       setHasPhotos: (hasPhotos: boolean) => set({ hasPhotos }),
       reset: () => {

--- a/apps/web/src/features/create-log/model/use-create-log-store.ts
+++ b/apps/web/src/features/create-log/model/use-create-log-store.ts
@@ -21,7 +21,7 @@ export const initialCreateLogValues = {
   endedAt: null as TimeValue | null,
   focus: null as FocusLevel | null,
   placeTags: [] as PlaceTagValue[],
-  scope: 'PRIVATE' as PostScope,
+  scope: 'PUBLIC' as PostScope,
 };
 
 const initialState = {

--- a/apps/web/src/features/create-log/model/use-create-log-store.ts
+++ b/apps/web/src/features/create-log/model/use-create-log-store.ts
@@ -51,11 +51,11 @@ export const useCreateLogStore = create(
     combine(initialState, (set) => ({
       setValues: (
         values: Partial<CreateLogStoredValues>,
-        draftPostId: number | null,
+        draftPostId?: number | null,
       ) =>
         set((state) => ({
           values: { ...state.values, ...values },
-          ...(draftPostId !== undefined ? { draftPostId } : draftPostId),
+          ...(draftPostId !== undefined ? { draftPostId } : {}),
         })),
       setHasPhotos: (hasPhotos: boolean) => set({ hasPhotos }),
       reset: () => {

--- a/apps/web/src/features/create-log/model/use-create-log-store.ts
+++ b/apps/web/src/features/create-log/model/use-create-log-store.ts
@@ -26,6 +26,7 @@ export const initialCreateLogValues = {
 
 const initialState = {
   values: initialCreateLogValues,
+  draftPostId: null as number | null,
   hasPhotos: false,
   hasHydrated: false,
 };
@@ -48,8 +49,14 @@ export function hasCreateLogValues(values: CreateLogStoredValues) {
 export const useCreateLogStore = create(
   persist(
     combine(initialState, (set) => ({
-      setValues: (values: Partial<CreateLogStoredValues>) =>
-        set((state) => ({ values: { ...state.values, ...values } })),
+      setValues: (
+        values: Partial<CreateLogStoredValues>,
+        draftPostId?: number | null,
+      ) =>
+        set((state) => ({
+          values: { ...state.values, ...values },
+          ...(draftPostId !== undefined ? { draftPostId } : {}),
+        })),
       setHasPhotos: (hasPhotos: boolean) => set({ hasPhotos }),
       reset: () => {
         set((state) => ({
@@ -61,7 +68,10 @@ export const useCreateLogStore = create(
     })),
     {
       name: 'plog:create-log',
-      partialize: (state) => ({ values: state.values }),
+      partialize: (state) => ({
+        values: state.values,
+        draftPostId: state.draftPostId,
+      }),
       onRehydrateStorage: () => (state) => {
         state?.setHasHydrated(true);
       },
@@ -81,6 +91,15 @@ export const useCreateLogStore = create(
   ),
 );
 
-export function getCreateLogDefaultValues(): CreateLogStoredValues {
-  return structuredClone(useCreateLogStore.getState().values);
+export function getCreateLogDefaultValues(
+  draftPostId: number | null = null,
+): CreateLogStoredValues {
+  const { values, draftPostId: storedDraftPostId } =
+    useCreateLogStore.getState();
+
+  if (storedDraftPostId !== draftPostId) {
+    return structuredClone(initialCreateLogValues);
+  }
+
+  return structuredClone(values);
 }

--- a/apps/web/src/features/select-review-tags/ui/ReviewTagsSheet.tsx
+++ b/apps/web/src/features/select-review-tags/ui/ReviewTagsSheet.tsx
@@ -106,7 +106,7 @@ export default function ReviewTagsSheet({
                   aria-selected={selected}
                   aria-controls={panelId}
                   className={cn(
-                    'label-lg flex shrink-0',
+                    'label-lg flex shrink-0 cursor-pointer',
                     selected
                       ? 'text-semantic-object-bold'
                       : 'text-semantic-object-subtle',

--- a/apps/web/src/shared/api/constants.ts
+++ b/apps/web/src/shared/api/constants.ts
@@ -9,6 +9,8 @@ export const CLIENT_BASE_URL = '/api';
 
 export const KAKAO_LOGIN_URL = `${SERVER_URL}/oauth2/authorization/kakao`;
 
+export const KAKAO_MAP_SDK_URL = `//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&libraries=services,clusterer&autoload=false`;
+
 export const API_ERROR_CODE = {
   INVALID_ACCESS_PATH: 'E400',
   REQUIRED_AUTH: 'E401',

--- a/apps/web/src/views/log-place-search/ui/SearchPlacePage.tsx
+++ b/apps/web/src/views/log-place-search/ui/SearchPlacePage.tsx
@@ -37,7 +37,26 @@ function CenteredView({ children }: { children: ReactNode }) {
   );
 }
 
-export default function SearchPlacePage() {
+function getSafeReturnPath(path: string | null) {
+  if (!path || !path.startsWith('/') || path.startsWith('//')) return '/log';
+
+  return path;
+}
+
+function getEditPostIdFromReturnPath(path: string) {
+  const [pathname, queryString] = path.split('?');
+  const postId = Number(new URLSearchParams(queryString).get('postId'));
+
+  return pathname === '/log' && Number.isInteger(postId) && postId > 0
+    ? postId
+    : null;
+}
+
+type SearchPlacePageProps = {
+  returnTo?: string;
+};
+
+export default function SearchPlacePage({ returnTo }: SearchPlacePageProps) {
   const [sdkLoaded, setSdkLoaded] = useState(false);
   const [sdkLoadError, setSdkLoadError] = useState(false);
 
@@ -54,6 +73,8 @@ export default function SearchPlacePage() {
   const { toast } = useToast();
 
   const displayState = sdkLoadError ? 'error' : searchState;
+  const returnPath = getSafeReturnPath(returnTo ?? null);
+  const returnPostId = getEditPostIdFromReturnPath(returnPath);
 
   const handleKakaoReady = useCallback(() => {
     window.kakao?.maps.load(() => setSdkLoaded(true));
@@ -71,8 +92,8 @@ export default function SearchPlacePage() {
         latitude: selectedPlace.latitude,
         longitude: selectedPlace.longitude,
       });
-      setCreateLogValues({ place: selectedPlace });
-      router.push('/log');
+      setCreateLogValues({ place: selectedPlace }, returnPostId);
+      router.push(returnPath);
     } catch {
       toast({
         type: 'error',
@@ -97,8 +118,8 @@ export default function SearchPlacePage() {
         latitude: selectedPlace.latitude,
         longitude: selectedPlace.longitude,
       });
-      setCreateLogValues({ place: selectedPlace });
-      router.push('/log');
+      setCreateLogValues({ place: selectedPlace }, returnPostId);
+      router.push(returnPath);
     } catch {
       toast({
         type: 'error',
@@ -121,7 +142,7 @@ export default function SearchPlacePage() {
         <AppBar
           variant="navigation"
           title="장소 검색"
-          onBack={() => router.push('/log')}
+          onBack={() => router.push(returnPath)}
         />
       </header>
       <Script

--- a/apps/web/src/views/log-place-search/ui/SearchPlacePage.tsx
+++ b/apps/web/src/views/log-place-search/ui/SearchPlacePage.tsx
@@ -20,6 +20,7 @@ import {
   useSaveRecentPlaceMutation,
 } from '@/features/place-search';
 
+import { KAKAO_MAP_SDK_URL } from '@/shared/api/constants';
 import {
   FetchErrorEmptyState,
   PlaceSearchIdleState,
@@ -146,7 +147,7 @@ export default function SearchPlacePage({ returnTo }: SearchPlacePageProps) {
         />
       </header>
       <Script
-        src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&libraries=services&autoload=false`}
+        src={KAKAO_MAP_SDK_URL}
         strategy="afterInteractive"
         onReady={handleKakaoReady}
         onError={() => setSdkLoadError(true)}

--- a/apps/web/src/views/log/model/mapper.ts
+++ b/apps/web/src/views/log/model/mapper.ts
@@ -42,6 +42,16 @@ function mapExistingPhoto(image: PostImage): ExistingPhotoPreview {
   };
 }
 
+function mapPostEditPlace(post: PostEditData['post']) {
+  return {
+    id: `edit-${post.place.latitude}-${post.place.longitude}-${post.place.name}`,
+    name: post.place.name,
+    address: post.place.address,
+    latitude: post.place.latitude,
+    longitude: post.place.longitude,
+  };
+}
+
 export function mapCreateLogForm(
   values: CreateLogFormValues,
 ): PostCreateRequest {
@@ -80,7 +90,7 @@ export function mapUpdateLogForm(
 ): PostUpdateRequest {
   return {
     ...mapCreateLogForm(values),
-    images: values.photos
+    keepImageIds: values.photos
       .filter(
         (photo): photo is ExistingPhotoPreview => photo.type === 'existing',
       )
@@ -96,16 +106,12 @@ export function mapPostEditResponseToFormValues({
   images,
   post,
 }: PostEditData): CreateLogFormValues {
+  const place = mapPostEditPlace(post);
+
   return {
     title: post.title,
     contents: post.contents,
-    place: {
-      id: `edit-${post.latitude}-${post.longitude}-${post.placeName}`,
-      name: post.placeName,
-      address: post.placeAddress,
-      latitude: post.latitude,
-      longitude: post.longitude,
-    },
+    place,
     categoryCode: post.categoryCode as PlaceCategoryValue,
     studyDate: parseStudyDate(post.studyDate),
     startedAt: post.startedAt,

--- a/apps/web/src/views/log/model/types.ts
+++ b/apps/web/src/views/log/model/types.ts
@@ -34,7 +34,7 @@ export type PostCreateRequest = {
 };
 
 export type PostUpdateRequest = PostCreateRequest & {
-  images: number[];
+  keepImageIds: number[];
 };
 
 export type PostImage = {
@@ -44,10 +44,7 @@ export type PostImage = {
 
 export type PostEditFields = Omit<PostCreateRequest, 'place'> & {
   studyTime: number;
-  placeName: string;
-  placeAddress: string;
-  latitude: number;
-  longitude: number;
+  place: PostPlace;
 };
 
 export type PostEditData = {

--- a/apps/web/src/views/log/model/use-photo-upload.ts
+++ b/apps/web/src/views/log/model/use-photo-upload.ts
@@ -1,3 +1,5 @@
+import { useCallback } from 'react';
+
 import { create } from 'zustand';
 
 import { type PostImage } from './types';
@@ -67,38 +69,47 @@ export function usePhotoUpload() {
   const photos = usePhotoStore((state) => state.photos);
   const setPhotos = usePhotoStore((state) => state.setPhotos);
 
-  const handleAddPhotos = (files: File[]) => {
-    setPhotos((currentPhotos) => {
-      const availableCount = MAX_PHOTO_COUNT - currentPhotos.length;
-      const nextFiles = files.slice(0, availableCount);
-      return [
-        ...currentPhotos,
-        ...nextFiles.map((file, index) => createPhotoPreview(file, index)),
-      ];
-    });
-  };
+  const handleAddPhotos = useCallback(
+    (files: File[]) => {
+      setPhotos((currentPhotos) => {
+        const availableCount = MAX_PHOTO_COUNT - currentPhotos.length;
+        const nextFiles = files.slice(0, availableCount);
+        return [
+          ...currentPhotos,
+          ...nextFiles.map((file, index) => createPhotoPreview(file, index)),
+        ];
+      });
+    },
+    [setPhotos],
+  );
 
-  const handleRemovePhoto = (id: string) => {
-    setPhotos((currentPhotos) => {
-      const targetPhoto = currentPhotos.find((photo) => photo.id === id);
-      if (targetPhoto) revokePhotoUrl(targetPhoto);
-      return currentPhotos.filter((photo) => photo.id !== id);
-    });
-  };
+  const handleRemovePhoto = useCallback(
+    (id: string) => {
+      setPhotos((currentPhotos) => {
+        const targetPhoto = currentPhotos.find((photo) => photo.id === id);
+        if (targetPhoto) revokePhotoUrl(targetPhoto);
+        return currentPhotos.filter((photo) => photo.id !== id);
+      });
+    },
+    [setPhotos],
+  );
 
-  const setExistingPhotos = (images: PostImage[]) => {
-    setPhotos((currentPhotos) => {
-      currentPhotos.forEach(revokePhotoUrl);
-      return images.slice(0, MAX_PHOTO_COUNT).map(createExistingPhotoPreview);
-    });
-  };
+  const setExistingPhotos = useCallback(
+    (images: PostImage[]) => {
+      setPhotos((currentPhotos) => {
+        currentPhotos.forEach(revokePhotoUrl);
+        return images.slice(0, MAX_PHOTO_COUNT).map(createExistingPhotoPreview);
+      });
+    },
+    [setPhotos],
+  );
 
-  const clearPhotos = () => {
+  const clearPhotos = useCallback(() => {
     setPhotos((currentPhotos) => {
       currentPhotos.forEach(revokePhotoUrl);
       return [];
     });
-  };
+  }, [setPhotos]);
 
   return {
     photos,

--- a/apps/web/src/views/log/ui/CreateLogPage.tsx
+++ b/apps/web/src/views/log/ui/CreateLogPage.tsx
@@ -315,7 +315,7 @@ export default function CreateLogPage({
 
       hasRestoredFormRef.current = true;
       reset(editFormValues);
-      if (!shouldRestoreDraft) {
+      if (!shouldRestoreDraft || photos.length === 0) {
         setExistingPhotos(editLogQuery.data.images.images);
       }
       return;
@@ -334,6 +334,7 @@ export default function CreateLogPage({
     hasStoreHydrated,
     isEditMode,
     normalizedEditPostId,
+    photos.length,
     reset,
     restoreDraft,
     setExistingPhotos,

--- a/apps/web/src/views/log/ui/CreateLogPage.tsx
+++ b/apps/web/src/views/log/ui/CreateLogPage.tsx
@@ -80,6 +80,7 @@ type SelectTriggerButtonProps = Omit<
 
 type CreateLogPageProps = {
   editPostId?: string;
+  restoreDraft?: boolean;
 };
 
 function SelectTriggerButton({
@@ -111,7 +112,10 @@ function SelectTriggerButton({
   );
 }
 
-export default function CreateLogPage({ editPostId }: CreateLogPageProps) {
+export default function CreateLogPage({
+  editPostId,
+  restoreDraft = false,
+}: CreateLogPageProps) {
   const router = useRouter();
   const numericEditPostId = editPostId ? Number(editPostId) : null;
   const normalizedEditPostId =
@@ -183,6 +187,7 @@ export default function CreateLogPage({ editPostId }: CreateLogPageProps) {
   );
   const resetCreateLog = useCreateLogStore((state) => state.reset);
   const createLogValues = useCreateLogStore((state) => state.values);
+  const createLogDraftPostId = useCreateLogStore((state) => state.draftPostId);
   const hasPhotosInStore = useCreateLogStore((state) => state.hasPhotos);
   const hasStoreHydrated = useCreateLogStore((state) => state.hasHydrated);
   const hasRestoredFormRef = useRef(false);
@@ -215,6 +220,10 @@ export default function CreateLogPage({ editPostId }: CreateLogPageProps) {
 
   const updateLogMutation = useUpdateLogMutation({
     postId: normalizedEditPostId,
+    onSuccess: () => {
+      clearPhotos();
+      resetCreateLog();
+    },
   });
   const editLogQuery = useEditLogQuery(normalizedEditPostId);
   const initialEditSnapshot = useMemo(() => {
@@ -251,14 +260,64 @@ export default function CreateLogPage({ editPostId }: CreateLogPageProps) {
     });
   };
 
+  const persistCurrentValuesToStore = useCallback(
+    (draftPostId: number | null) => {
+      const values = getValues();
+
+      setCreateLogValues(
+        {
+          title: values.title,
+          contents: values.contents,
+          place: values.place,
+          categoryCode: values.categoryCode,
+          studyDate: values.studyDate,
+          startedAt: values.startedAt,
+          endedAt: values.endedAt,
+          focus: values.focus,
+          placeTags: values.placeTags,
+          scope: values.scope,
+        },
+        draftPostId,
+      );
+    },
+    [getValues, setCreateLogValues],
+  );
+
+  const handlePlaceSearchOpen = () => {
+    const returnPath =
+      isEditMode && normalizedEditPostId !== null
+        ? `/log?postId=${normalizedEditPostId}&restoreDraft=1`
+        : '/log';
+
+    persistCurrentValuesToStore(isEditMode ? normalizedEditPostId : null);
+
+    router.push(
+      returnPath === '/log'
+        ? '/log/place-search'
+        : `/log/place-search?returnTo=${encodeURIComponent(returnPath)}`,
+    );
+  };
+
   useEffect(() => {
+    if (!hasStoreHydrated) return;
+
     if (isEditMode) {
       if (!editLogQuery.data || hasRestoredFormRef.current) return;
 
-      const editFormValues = mapPostEditResponseToFormValues(editLogQuery.data);
+      const shouldRestoreDraft =
+        restoreDraft && createLogDraftPostId === normalizedEditPostId;
+      const editFormValues = {
+        ...mapPostEditResponseToFormValues(editLogQuery.data),
+        ...(shouldRestoreDraft
+          ? getCreateLogDefaultValues(normalizedEditPostId)
+          : {}),
+      };
+
       hasRestoredFormRef.current = true;
       reset(editFormValues);
-      setExistingPhotos(editLogQuery.data.images.images);
+      if (!shouldRestoreDraft) {
+        setExistingPhotos(editLogQuery.data.images.images);
+      }
       return;
     }
 
@@ -271,9 +330,12 @@ export default function CreateLogPage({ editPostId }: CreateLogPageProps) {
     });
   }, [
     editLogQuery.data,
+    createLogDraftPostId,
     hasStoreHydrated,
     isEditMode,
+    normalizedEditPostId,
     reset,
+    restoreDraft,
     setExistingPhotos,
   ]);
 
@@ -678,7 +740,7 @@ export default function CreateLogPage({ editPostId }: CreateLogPageProps) {
                   placeholder="위치를 입력해 주세요."
                   readOnly
                   onClear={handleClearPlaceName}
-                  onClick={() => router.push('/log/place-search')}
+                  onClick={handlePlaceSearchOpen}
                 />
               </Field>
             </div>

--- a/apps/web/src/views/log/ui/CreateLogPage.tsx
+++ b/apps/web/src/views/log/ui/CreateLogPage.tsx
@@ -256,22 +256,18 @@ export default function CreateLogPage({ editPostId }: CreateLogPageProps) {
       if (!editLogQuery.data || hasRestoredFormRef.current) return;
 
       const editFormValues = mapPostEditResponseToFormValues(editLogQuery.data);
+      hasRestoredFormRef.current = true;
       reset(editFormValues);
       setExistingPhotos(editLogQuery.data.images.images);
-      queueMicrotask(() => {
-        hasRestoredFormRef.current = true;
-      });
       return;
     }
 
     if (!hasStoreHydrated || hasRestoredFormRef.current) return;
 
+    hasRestoredFormRef.current = true;
     reset({
       ...getCreateLogDefaultValues(),
       photos: [],
-    });
-    queueMicrotask(() => {
-      hasRestoredFormRef.current = true;
     });
   }, [
     editLogQuery.data,

--- a/apps/web/src/views/map/ui/MapPage.tsx
+++ b/apps/web/src/views/map/ui/MapPage.tsx
@@ -9,6 +9,7 @@ import { BottomSheet, Icon, Input } from '@plog/ui';
 
 import { type MapSortType, type PlaceLayer } from '@/entities/place';
 
+import { KAKAO_MAP_SDK_URL } from '@/shared/api/constants';
 import { useUserLocation } from '@/shared/lib/geolocation';
 
 import { useKakaoMap } from '../lib/use-kakao-map';
@@ -178,7 +179,7 @@ export default function MapPage() {
   return (
     <>
       <Script
-        src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${process.env.NEXT_PUBLIC_KAKAO_API_KEY}&libraries=clusterer&autoload=false`}
+        src={KAKAO_MAP_SDK_URL}
         strategy="afterInteractive"
         onReady={handleLoad}
       />


### PR DESCRIPTION
## 📌 관련 이슈

- closes #115

## 📝 작업 내용

- [x] 게시글 수정 시 기존 장소 정보가 정상적으로 표시되도록 수정
- [x] 수정 중 장소 선택 후 /log로 이동하면서 입력값이 초기화되던 문제 수정
- [x] 수정 페이지 진입 시 `Maximum update depth exceeded` 오류 수정
- [x] 수정 페이지에서 기존 게시글 데이터를 form에 복원할 때 `reset()`이 반복 실행되던 문제 수정
- [x] 사진 업로드 훅의 반환 함수들을 `useCallback`으로 고정해 effect dependency가 매 렌더마다 변경되지 않도록 수정
- [x] 게시글 수정 요청 payload를 백엔드 스펙에 맞게 keepImageIds로 변경
## 🔎 자세한 설명

> 왜 이렇게 변경했나요? 기술적 선택의 근거나 배경을 설명해 주세요.

### ✅ 게시글 수정 시 기존 장소 정보가 정상적으로 표시되도록 수정
게시글 수정 조회 응답에서 장소 정보가 place.name, place.address, place.latitude, place.longitude 형태로 내려오고 있었지만, 기존 프론트 코드는 placeName, placeAddress, latitude, longitude를 참조하고 있었습니다.

실제 백엔드 응답 스펙에 맞춰 수정 화면의 form 값 매핑을 post.place 기준으로 변경해, 기존 장소 정보가 정상적으로 표시되도록 수정했습니다.

### ✅ 수정 중 장소 선택 후 입력값이 초기화되던 문제 수정
수정 화면에서 장소 검색 페이지로 이동한 뒤 장소를 선택하면 기존 수정 경로인 /log?postId=...가 유지되지 않고 /log로 이동하면서 새 글 작성 흐름처럼 동작하는 문제가 있었습니다.

이를 해결하기 위해 장소 검색 진입 전 현재 수정 중인 form 값을 임시 저장하고, 장소 선택 후 returnTo 경로를 통해 다시 기존 수정 경로로 복귀하도록 수정했습니다. 또한 저장된 draft가 어떤 게시글 수정용인지 구분하기 위해 draftPostId를 함께 저장하도록 변경했습니다.

### ✅ 수정 페이지 진입 시 **`Maximum update depth exceeded`** 오류 수정
기존에는 수정 데이터를 form에 복원하는 과정에서 reset()이 반복 실행될 수 있는 구조였습니다. 특히 복원 완료 여부를 나타내는 hasRestoredFormRef.current 값이 늦게 변경되면, reset()으로 인한 재렌더 이후에도 effect가 다시 실행될 수 있었습니다.

이를 방지하기 위해 reset() 호출 전에 hasRestoredFormRef.current = true를 먼저 설정하도록 변경했습니다. 이를 통해 수정 데이터 복원은 최초 1회만 실행되도록 보장했습니다.

### ✅ 사진 업로드 훅 함수 참조 안정화
기존에는 `hasRestoredFormRef.current` 값을 `queueMicrotask` 안에서 늦게 `true`로 변경하고 있었기 때문에, `reset()`으로 인한 재렌더가 먼저 발생하면 복원 완료 여부를 막지 못하는 문제가 있었습니다. 이를 해결하기 위해 `reset()` 호출 전에 `hasRestoredFormRef.current = true`를 먼저 설정하도록 변경했습니다.

또한 `usePhotoUpload`에서 반환하는 `setExistingPhotos`, `clearPhotos`, `handleAddPhotos`, `handleRemovePhoto` 함수가 매 렌더마다 새로 생성되고 있었기 때문에 effect dependency가 불안정해질 수 있었습니다. 이를 `useCallback`으로 감싸 함수 참조를 안정화했습니다.

### ✅ 게시글 수정 요청 payload 스펙 반영
게시글 수정 요청에서 기존 이미지 유지 ID를 images 필드로 전달하고 있었지만, 백엔드 스웨거 스펙에서는 keepImageIds 필드를 사용하고 있었습니다.

이에 맞춰 수정 요청 타입과 mapper를 변경하여, 기존 이미지 ID는 keepImageIds로 전달하고 새로 추가한 이미지 파일은 기존처럼 multipart의 images 필드로 전달되도록 유지했습니다.


## 🖼️ 스크린샷

> UI 변경이 있다면 Before / After 스크린샷을 첨부해 주세요.

## 💬 리뷰어에게

> 리뷰 시 집중적으로 봐줬으면 하는 부분이나 참고할 내용을 적어주세요.

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
