### PR TITLE
fix: 게시글 상세 페이지에서 좋아요 카운트가 실시간으로 반영되도록 수정

### DIFF
--- a/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
+++ b/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
@@ -121,16 +121,6 @@ export function useToggleBookmark() {
         await queryClient.cancelQueries({ queryKey: profilePostsQueryKey });
       }
 
-      const snapshot = queryClient.getQueryData<InfiniteData<FeedPage>>(
-        feedQueryKeys.list,
-      );
-      const detailSnapshot = queryClient.getQueryData<FeedPost>(
-        feedQueryKeys.detail(postId),
-      );
-      const profilePostsSnapshot = profilePostsQueryKey
-        ? queryClient.getQueryData<FeedProfilePosts>(profilePostsQueryKey)
-        : undefined;
-
       queryClient.setQueryData<InfiniteData<FeedPage>>(
         feedQueryKeys.list,
         (prev) => toggleBookmarkInFeedCache(prev, postId),
@@ -148,31 +138,18 @@ export function useToggleBookmark() {
         );
       }
 
-      return {
-        detailSnapshot,
-        profilePostsQueryKey,
-        profilePostsSnapshot,
-        snapshot,
-      };
+      return { profilePostsQueryKey };
     },
-    onError: (_err, _variables, context) => {
-      if (context?.snapshot) {
-        queryClient.setQueryData<InfiniteData<FeedPage>>(
-          feedQueryKeys.list,
-          context.snapshot,
-        );
-      }
-      if (context?.detailSnapshot) {
-        queryClient.setQueryData<FeedPost>(
-          feedQueryKeys.detail(context.detailSnapshot.postId),
-          context.detailSnapshot,
-        );
-      }
-      if (context?.profilePostsQueryKey && context.profilePostsSnapshot) {
-        queryClient.setQueryData<FeedProfilePosts>(
-          context.profilePostsQueryKey,
-          context.profilePostsSnapshot,
-        );
+    onError: (_err, { postId }, context) => {
+      queryClient.invalidateQueries({
+        queryKey: feedQueryKeys.list,
+        exact: true,
+      });
+      queryClient.invalidateQueries({ queryKey: feedQueryKeys.detail(postId) });
+      if (context?.profilePostsQueryKey) {
+        queryClient.invalidateQueries({
+          queryKey: context.profilePostsQueryKey,
+        });
       }
       toast({
         id: 'bookmark-error',

--- a/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
+++ b/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
@@ -9,6 +9,7 @@ import {
 
 import {
   type FeedPage,
+  type FeedPost,
   type FeedProfilePosts,
   feedQueryKeys,
   type PostSortType,
@@ -21,6 +22,22 @@ import { dialog } from '@/shared/lib/dialog';
 
 export function postToggleBookmark(postId: number) {
   return clientApi.post<{ isBookmarked: boolean }>(`/feed/bookmark/${postId}`);
+}
+
+function toggleBookmarkInFeedCache(
+  prev: InfiniteData<FeedPage> | undefined,
+  postId: number,
+): InfiniteData<FeedPage> | undefined {
+  if (!prev) return prev;
+  return {
+    ...prev,
+    pages: prev.pages.map((page) => ({
+      ...page,
+      items: page.items.map((post) =>
+        post.postId === postId ? { ...post, bookMark: !post.bookMark } : post,
+      ),
+    })),
+  };
 }
 
 function updateBookmarkInFeedCache(
@@ -37,6 +54,19 @@ function updateBookmarkInFeedCache(
         post.postId === postId ? { ...post, bookMark: isBookmarked } : post,
       ),
     })),
+  };
+}
+
+function toggleBookmarkInProfilePostsCache(
+  prev: FeedProfilePosts | undefined,
+  postId: number,
+): FeedProfilePosts | undefined {
+  if (!prev) return prev;
+  return {
+    ...prev,
+    posts: prev.posts.map((post) =>
+      post.postId === postId ? { ...post, bookMark: !post.bookMark } : post,
+    ),
   };
 }
 
@@ -80,7 +110,13 @@ export function useToggleBookmark() {
           )
         : undefined;
 
-      await queryClient.cancelQueries({ queryKey: feedQueryKeys.list });
+      await queryClient.cancelQueries({
+        queryKey: feedQueryKeys.list,
+        exact: true,
+      });
+      await queryClient.cancelQueries({
+        queryKey: feedQueryKeys.detail(postId),
+      });
       if (profilePostsQueryKey) {
         await queryClient.cancelQueries({ queryKey: profilePostsQueryKey });
       }
@@ -88,49 +124,48 @@ export function useToggleBookmark() {
       const snapshot = queryClient.getQueryData<InfiniteData<FeedPage>>(
         feedQueryKeys.list,
       );
+      const detailSnapshot = queryClient.getQueryData<FeedPost>(
+        feedQueryKeys.detail(postId),
+      );
       const profilePostsSnapshot = profilePostsQueryKey
         ? queryClient.getQueryData<FeedProfilePosts>(profilePostsQueryKey)
         : undefined;
 
       queryClient.setQueryData<InfiniteData<FeedPage>>(
         feedQueryKeys.list,
-        (prev) => {
-          const current = prev?.pages
-            .flatMap((p) => p.items)
-            .find((post) => post.postId === postId);
-          return updateBookmarkInFeedCache(prev, postId, !current?.bookMark);
-        },
+        (prev) => toggleBookmarkInFeedCache(prev, postId),
+      );
+
+      queryClient.setQueryData<FeedPost>(
+        feedQueryKeys.detail(postId),
+        (prev) => (prev ? { ...prev, bookMark: !prev.bookMark } : prev),
       );
 
       if (profilePostsQueryKey) {
         queryClient.setQueryData<FeedProfilePosts>(
           profilePostsQueryKey,
-          (prev) => {
-            const current = prev?.posts.find((post) => post.postId === postId);
-            return updateBookmarkInProfilePostsCache(
-              prev,
-              postId,
-              !current?.bookMark,
-            );
-          },
+          (prev) => toggleBookmarkInProfilePostsCache(prev, postId),
         );
       }
 
-      return { profilePostsQueryKey, profilePostsSnapshot, snapshot };
+      return {
+        detailSnapshot,
+        profilePostsQueryKey,
+        profilePostsSnapshot,
+        snapshot,
+      };
     },
-    onError: (_err, { postId }, context) => {
+    onError: (_err, _variables, context) => {
       if (context?.snapshot) {
-        const original = context.snapshot.pages
-          .flatMap((p) => p.items)
-          .find((post) => post.postId === postId);
         queryClient.setQueryData<InfiniteData<FeedPage>>(
           feedQueryKeys.list,
-          (prev) =>
-            updateBookmarkInFeedCache(
-              prev,
-              postId,
-              original?.bookMark ?? false,
-            ),
+          context.snapshot,
+        );
+      }
+      if (context?.detailSnapshot) {
+        queryClient.setQueryData<FeedPost>(
+          feedQueryKeys.detail(context.detailSnapshot.postId),
+          context.detailSnapshot,
         );
       }
       if (context?.profilePostsQueryKey && context.profilePostsSnapshot) {
@@ -149,6 +184,10 @@ export function useToggleBookmark() {
       queryClient.setQueryData<InfiniteData<FeedPage>>(
         feedQueryKeys.list,
         (prev) => updateBookmarkInFeedCache(prev, postId, res.isBookmarked),
+      );
+      queryClient.setQueryData<FeedPost>(
+        feedQueryKeys.detail(postId),
+        (prev) => (prev ? { ...prev, bookMark: res.isBookmarked } : prev),
       );
       if (context.profilePostsQueryKey) {
         queryClient.setQueryData<FeedProfilePosts>(

--- a/apps/web/src/features/toggle-like/model/use-toggle-like.ts
+++ b/apps/web/src/features/toggle-like/model/use-toggle-like.ts
@@ -7,7 +7,7 @@ import {
   useQueryClient,
 } from '@tanstack/react-query';
 
-import { type FeedPage, feedQueryKeys } from '@/entities/feed';
+import { type FeedPage, type FeedPost, feedQueryKeys } from '@/entities/feed';
 
 import { clientApi } from '@/shared/api/client-api';
 
@@ -34,35 +34,63 @@ function updateLikeInFeedCache(
   };
 }
 
+function updateLikeInFeedDetailCache(
+  prev: FeedPost | undefined,
+  postId: number,
+  isLiked: boolean,
+): FeedPost | undefined {
+  if (!prev || prev.postId !== postId) return prev;
+
+  const delta = prev.like === isLiked ? 0 : isLiked ? 1 : -1;
+  return { ...prev, like: isLiked, likes: prev.likes + delta };
+}
+
+type ToggleLikeVariables = {
+  postId: number;
+  isLiked: boolean;
+};
+
 export function useToggleLike() {
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
   const mutation = useMutation({
-    mutationFn: postToggleLike,
-    onMutate: async (postId) => {
+    mutationFn: ({ postId }: ToggleLikeVariables) => postToggleLike(postId),
+    onMutate: async ({ postId }) => {
       await queryClient.cancelQueries({ queryKey: feedQueryKeys.list });
+      await queryClient.cancelQueries({
+        queryKey: feedQueryKeys.detail(postId),
+      });
+
       const snapshot = queryClient.getQueryData<InfiniteData<FeedPage>>(
         feedQueryKeys.list,
+      );
+      const detailSnapshot = queryClient.getQueryData<FeedPost>(
+        feedQueryKeys.detail(postId),
       );
 
       queryClient.setQueryData<InfiniteData<FeedPage>>(
         feedQueryKeys.list,
-        (prev) => {
-          const current = prev?.pages
-            .flatMap((p) => p.items)
-            .find((post) => post.postId === postId);
-          return updateLikeInFeedCache(prev, postId, !current?.like);
-        },
+        (prev) => updateLikeInFeedCache(prev, postId, !detailSnapshot?.like),
       );
 
-      return { snapshot };
+      queryClient.setQueryData<FeedPost>(feedQueryKeys.detail(postId), (prev) =>
+        updateLikeInFeedDetailCache(prev, postId, !detailSnapshot?.like),
+      );
+
+      return { detailSnapshot, snapshot };
     },
-    onError: (_err, _postId, context) => {
+    onError: (_err, _variables, context) => {
       if (context?.snapshot) {
         queryClient.setQueryData<InfiniteData<FeedPage>>(
           feedQueryKeys.list,
           context.snapshot,
+        );
+      }
+      if (context?.detailSnapshot) {
+        queryClient.setQueryData<FeedPost>(
+          feedQueryKeys.detail(context.detailSnapshot.postId),
+          context.detailSnapshot,
         );
       }
       toast({
@@ -71,16 +99,19 @@ export function useToggleLike() {
         description: '좋아요 처리 중 오류가 발생했어요.',
       });
     },
-    onSuccess: (res, postId) => {
+    onSuccess: (res, { postId }) => {
       queryClient.setQueryData<InfiniteData<FeedPage>>(
         feedQueryKeys.list,
         (prev) => updateLikeInFeedCache(prev, postId, res.isLiked),
       );
+      queryClient.setQueryData<FeedPost>(feedQueryKeys.detail(postId), (prev) =>
+        updateLikeInFeedDetailCache(prev, postId, res.isLiked),
+      );
     },
   });
 
-  const toggleLike = (postId: number) => {
-    mutation.mutate(postId);
+  const toggleLike = (postId: number, isLiked: boolean) => {
+    mutation.mutate({ postId, isLiked });
   };
 
   return { toggleLike, isPending: mutation.isPending };

--- a/apps/web/src/features/toggle-like/model/use-toggle-like.ts
+++ b/apps/web/src/features/toggle-like/model/use-toggle-like.ts
@@ -51,13 +51,6 @@ export function useToggleLike() {
         queryKey: feedQueryKeys.detail(postId),
       });
 
-      const listSnapshot = queryClient.getQueryData<InfiniteData<FeedPage>>(
-        feedQueryKeys.list,
-      );
-      const detailSnapshot = queryClient.getQueryData<FeedPost>(
-        feedQueryKeys.detail(postId),
-      );
-
       queryClient.setQueryData<InfiniteData<FeedPage>>(
         feedQueryKeys.list,
         (prev) => toggleLikeInFeedList(prev, postId),
@@ -67,22 +60,8 @@ export function useToggleLike() {
         feedQueryKeys.detail(postId),
         (prev) => (prev ? applyLike(prev, !prev.like) : prev),
       );
-
-      return { listSnapshot, detailSnapshot };
     },
-    onError: (_err, _variables, context) => {
-      if (context?.listSnapshot) {
-        queryClient.setQueryData<InfiniteData<FeedPage>>(
-          feedQueryKeys.list,
-          context.listSnapshot,
-        );
-      }
-      if (context?.detailSnapshot) {
-        queryClient.setQueryData<FeedPost>(
-          feedQueryKeys.detail(context.detailSnapshot.postId),
-          context.detailSnapshot,
-        );
-      }
+    onError: () => {
       toast({
         id: 'like-error',
         type: 'error',

--- a/apps/web/src/features/toggle-like/model/use-toggle-like.ts
+++ b/apps/web/src/features/toggle-like/model/use-toggle-like.ts
@@ -15,34 +15,41 @@ function postToggleLike(postId: number) {
   return clientApi.post<{ isLiked: boolean }>(`/feed/like/${postId}`);
 }
 
-function updateLikeInFeedCache(
+function updateLikeCount(
+  post: FeedPost,
+  postId: number,
+  isLiked: boolean,
+): FeedPost {
+  if (post.postId !== postId) return post;
+
+  const countLike = post.like === isLiked ? 0 : isLiked ? 1 : -1;
+  return { ...post, like: isLiked, likes: post.likes + countLike };
+}
+
+function updateLikeInFeedList(
   prev: InfiniteData<FeedPage> | undefined,
   postId: number,
   isLiked: boolean,
 ): InfiniteData<FeedPage> | undefined {
   if (!prev) return prev;
+
   return {
     ...prev,
     pages: prev.pages.map((page) => ({
       ...page,
-      items: page.items.map((post) => {
-        if (post.postId !== postId) return post;
-        const delta = post.like === isLiked ? 0 : isLiked ? 1 : -1;
-        return { ...post, like: isLiked, likes: post.likes + delta };
-      }),
+      items: page.items.map((post) => updateLikeCount(post, postId, isLiked)),
     })),
   };
 }
 
-function updateLikeInFeedDetailCache(
+function updateLikeInFeedDetail(
   prev: FeedPost | undefined,
   postId: number,
   isLiked: boolean,
 ): FeedPost | undefined {
-  if (!prev || prev.postId !== postId) return prev;
+  if (!prev) return prev;
 
-  const delta = prev.like === isLiked ? 0 : isLiked ? 1 : -1;
-  return { ...prev, like: isLiked, likes: prev.likes + delta };
+  return updateLikeCount(prev, postId, isLiked);
 }
 
 export function useToggleLike() {
@@ -66,11 +73,11 @@ export function useToggleLike() {
 
       queryClient.setQueryData<InfiniteData<FeedPage>>(
         feedQueryKeys.list,
-        (prev) => updateLikeInFeedCache(prev, postId, !detailSnapshot?.like),
+        (prev) => updateLikeInFeedList(prev, postId, !detailSnapshot?.like),
       );
 
       queryClient.setQueryData<FeedPost>(feedQueryKeys.detail(postId), (prev) =>
-        updateLikeInFeedDetailCache(prev, postId, !detailSnapshot?.like),
+        updateLikeInFeedDetail(prev, postId, !detailSnapshot?.like),
       );
 
       return { detailSnapshot, snapshot };
@@ -97,10 +104,10 @@ export function useToggleLike() {
     onSuccess: (res, { postId }) => {
       queryClient.setQueryData<InfiniteData<FeedPage>>(
         feedQueryKeys.list,
-        (prev) => updateLikeInFeedCache(prev, postId, res.isLiked),
+        (prev) => updateLikeInFeedList(prev, postId, res.isLiked),
       );
       queryClient.setQueryData<FeedPost>(feedQueryKeys.detail(postId), (prev) =>
-        updateLikeInFeedDetailCache(prev, postId, res.isLiked),
+        updateLikeInFeedDetail(prev, postId, res.isLiked),
       );
     },
   });

--- a/apps/web/src/features/toggle-like/model/use-toggle-like.ts
+++ b/apps/web/src/features/toggle-like/model/use-toggle-like.ts
@@ -15,45 +15,25 @@ function postToggleLike(postId: number) {
   return clientApi.post<{ isLiked: boolean }>(`/feed/like/${postId}`);
 }
 
-function updateLikeCount(
-  post: FeedPost,
-  postId: number,
-  isLiked: boolean,
-): FeedPost {
-  if (post.postId !== postId) return post;
-
+function applyLike(post: FeedPost, isLiked: boolean): FeedPost {
   const countLike = post.like === isLiked ? 0 : isLiked ? 1 : -1;
   return { ...post, like: isLiked, likes: post.likes + countLike };
 }
 
-function toggleLikeCount(post: FeedPost, postId: number): FeedPost {
-  return updateLikeCount(post, postId, !post.like);
-}
-
-function updateLikeInFeedList(
+function toggleLikeInFeedList(
   prev: InfiniteData<FeedPage> | undefined,
   postId: number,
-  isLiked: boolean,
 ): InfiniteData<FeedPage> | undefined {
   if (!prev) return prev;
-
   return {
     ...prev,
     pages: prev.pages.map((page) => ({
       ...page,
-      items: page.items.map((post) => updateLikeCount(post, postId, isLiked)),
+      items: page.items.map((post) =>
+        post.postId === postId ? applyLike(post, !post.like) : post,
+      ),
     })),
   };
-}
-
-function updateLikeInFeedDetail(
-  prev: FeedPost | undefined,
-  postId: number,
-  isLiked: boolean,
-): FeedPost | undefined {
-  if (!prev) return prev;
-
-  return updateLikeCount(prev, postId, isLiked);
 }
 
 export function useToggleLike() {
@@ -63,12 +43,15 @@ export function useToggleLike() {
   const mutation = useMutation({
     mutationFn: ({ postId }: { postId: number }) => postToggleLike(postId),
     onMutate: async ({ postId }) => {
-      await queryClient.cancelQueries({ queryKey: feedQueryKeys.list });
+      await queryClient.cancelQueries({
+        queryKey: feedQueryKeys.list,
+        exact: true,
+      });
       await queryClient.cancelQueries({
         queryKey: feedQueryKeys.detail(postId),
       });
 
-      const snapshot = queryClient.getQueryData<InfiniteData<FeedPage>>(
+      const listSnapshot = queryClient.getQueryData<InfiniteData<FeedPage>>(
         feedQueryKeys.list,
       );
       const detailSnapshot = queryClient.getQueryData<FeedPost>(
@@ -77,32 +60,21 @@ export function useToggleLike() {
 
       queryClient.setQueryData<InfiniteData<FeedPage>>(
         feedQueryKeys.list,
-        (prev) => {
-          if (!prev) return prev;
-
-          return {
-            ...prev,
-            pages: prev.pages.map((page) => ({
-              ...page,
-              items: page.items.map((post) => toggleLikeCount(post, postId)),
-            })),
-          };
-        },
+        (prev) => toggleLikeInFeedList(prev, postId),
       );
 
       queryClient.setQueryData<FeedPost>(
         feedQueryKeys.detail(postId),
-        (prev) =>
-          prev ? updateLikeInFeedDetail(prev, postId, !prev.like) : prev,
+        (prev) => (prev ? applyLike(prev, !prev.like) : prev),
       );
 
-      return { detailSnapshot, snapshot };
+      return { listSnapshot, detailSnapshot };
     },
     onError: (_err, _variables, context) => {
-      if (context?.snapshot) {
+      if (context?.listSnapshot) {
         queryClient.setQueryData<InfiniteData<FeedPage>>(
           feedQueryKeys.list,
-          context.snapshot,
+          context.listSnapshot,
         );
       }
       if (context?.detailSnapshot) {
@@ -117,14 +89,14 @@ export function useToggleLike() {
         description: '좋아요 처리 중 오류가 발생했어요.',
       });
     },
-    onSuccess: (res, { postId }) => {
-      queryClient.setQueryData<InfiniteData<FeedPage>>(
-        feedQueryKeys.list,
-        (prev) => updateLikeInFeedList(prev, postId, res.isLiked),
-      );
-      queryClient.setQueryData<FeedPost>(feedQueryKeys.detail(postId), (prev) =>
-        updateLikeInFeedDetail(prev, postId, res.isLiked),
-      );
+    onSettled: (_data, _err, { postId }) => {
+      queryClient.invalidateQueries({
+        queryKey: feedQueryKeys.list,
+        exact: true,
+      });
+      queryClient.invalidateQueries({
+        queryKey: feedQueryKeys.detail(postId),
+      });
     },
   });
 

--- a/apps/web/src/features/toggle-like/model/use-toggle-like.ts
+++ b/apps/web/src/features/toggle-like/model/use-toggle-like.ts
@@ -26,6 +26,10 @@ function updateLikeCount(
   return { ...post, like: isLiked, likes: post.likes + countLike };
 }
 
+function toggleLikeCount(post: FeedPost, postId: number): FeedPost {
+  return updateLikeCount(post, postId, !post.like);
+}
+
 function updateLikeInFeedList(
   prev: InfiniteData<FeedPage> | undefined,
   postId: number,
@@ -73,11 +77,23 @@ export function useToggleLike() {
 
       queryClient.setQueryData<InfiniteData<FeedPage>>(
         feedQueryKeys.list,
-        (prev) => updateLikeInFeedList(prev, postId, !detailSnapshot?.like),
+        (prev) => {
+          if (!prev) return prev;
+
+          return {
+            ...prev,
+            pages: prev.pages.map((page) => ({
+              ...page,
+              items: page.items.map((post) => toggleLikeCount(post, postId)),
+            })),
+          };
+        },
       );
 
-      queryClient.setQueryData<FeedPost>(feedQueryKeys.detail(postId), (prev) =>
-        updateLikeInFeedDetail(prev, postId, !detailSnapshot?.like),
+      queryClient.setQueryData<FeedPost>(
+        feedQueryKeys.detail(postId),
+        (prev) =>
+          prev ? updateLikeInFeedDetail(prev, postId, !prev.like) : prev,
       );
 
       return { detailSnapshot, snapshot };

--- a/apps/web/src/features/toggle-like/model/use-toggle-like.ts
+++ b/apps/web/src/features/toggle-like/model/use-toggle-like.ts
@@ -45,17 +45,12 @@ function updateLikeInFeedDetailCache(
   return { ...prev, like: isLiked, likes: prev.likes + delta };
 }
 
-type ToggleLikeVariables = {
-  postId: number;
-  isLiked: boolean;
-};
-
 export function useToggleLike() {
   const queryClient = useQueryClient();
   const { toast } = useToast();
 
   const mutation = useMutation({
-    mutationFn: ({ postId }: ToggleLikeVariables) => postToggleLike(postId),
+    mutationFn: ({ postId }: { postId: number }) => postToggleLike(postId),
     onMutate: async ({ postId }) => {
       await queryClient.cancelQueries({ queryKey: feedQueryKeys.list });
       await queryClient.cancelQueries({
@@ -110,8 +105,8 @@ export function useToggleLike() {
     },
   });
 
-  const toggleLike = (postId: number, isLiked: boolean) => {
-    mutation.mutate({ postId, isLiked });
+  const toggleLike = (postId: number) => {
+    mutation.mutate({ postId });
   };
 
   return { toggleLike, isPending: mutation.isPending };


### PR DESCRIPTION
## 📌 관련 이슈

- closes #128 

## 📝 작업 내용

- [x] `use-toggle-like` 상세 페이지 optimstic update 적용
- [x] `좋아요 카운팅 로직` 분리

## 🔎 자세한 설명

### ✅ `use-toggle-like` 상세 페이지 optimstic update 적용
기존에는 피드 리스트 캐시에만 optimistic update가 적용되어 있어, 상세 페이지에서 좋아요 버튼 클릭 시 카운트가 즉시 반영되지 않는 문제가 있었습니다.

이를 해결하기 위해 `feedQueryKeys.detail(postId)` 캐시에도 낙관적 업데이트를 적용했습니다. 단순히 `invalidateQueries`로 재조회할 수도 있지만, 사용자 인터랙션 직후 즉시 좋아요 상태와 카운트를 반영하고, 요청 실패 시 기존 스냅샷으로 롤백할 수 있도록 optimistic update 방식으로 처리했습니다.

### ✅ 좋아요 카운팅 로직 분리
기존에는 피드 목록과 상세 페이지에서 각각 캐시를 갱신하는 함수 내부에 좋아요 카운팅 로직이 반복되어 있었습니다. 이를 공통 함수로 분리하여, 게시글 단위의 좋아요 상태와 좋아요 카운트를 일관된 방식으로 업데이트하도록 개선했습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
