### PR TITLE
fix: 장소 카테고리 색상 변경 및 레이아웃 구조 변경

### DIFF
--- a/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
+++ b/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
@@ -346,7 +346,7 @@ export default function FeedDetailCard({ postId }: { postId: string }) {
               </div>
             )}
           </div>
-          <div className="flex flex-col gap-2.5 px-6 pt-3">
+          <div className="flex flex-col gap-4 px-6 pt-3">
             {!isMyPost && (
               <div className="flex justify-between">
                 <div className="flex items-center gap-1.5">
@@ -364,23 +364,21 @@ export default function FeedDetailCard({ postId }: { postId: string }) {
                 </div>
               </div>
             )}
-            <div className="flex flex-col gap-0.5">
+            <div className="flex flex-col gap-4">
               <div className="flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <span className="title-xs text-semantic-object-boldest">
-                    {post.placeName}
-                  </span>
-                  {post.category && (
-                    <Badge color="skyblue" variant="soft">
-                      {post.category}
-                    </Badge>
-                  )}
-                </div>
+                <Badge variant="soft" color="orange">
+                  {post.category}
+                </Badge>
                 {isMyPost && <CopyLinkButton postId={post.postId} />}
               </div>
-              <p className="body-sm text-semantic-object-normal">
-                {post.address}
-              </p>
+              <div className="flex flex-col gap-1">
+                <span className="title-xs text-semantic-object-boldest">
+                  {post.placeName}
+                </span>
+                <p className="body-sm text-semantic-object-normal">
+                  {post.address}
+                </p>
+              </div>
             </div>
             <FeedStatsSummary
               isUserOwnFeed={isMyPost}


### PR DESCRIPTION
## 📌 관련 이슈

- closes #132 

## 📝 작업 내용

- [x] 상세 페이지 장소 카테고리 뱃지 색상 변경
- [x] 상세 페이지 레이아웃 구조 변경

## 🔎 자세한 설명

## 🖼️ 스크린샷

> UI 변경이 있다면 Before / After 스크린샷을 첨부해 주세요.

Before 
<img width="539" height="275" alt="스크린샷 2026-05-14 오전 1 40 41" src="https://github.com/user-attachments/assets/eea49b07-6f35-4836-b8ff-2176e31a6cf3" />

<img width="578" height="260" alt="스크린샷 2026-05-14 오전 1 40 35" src="https://github.com/user-attachments/assets/7e580512-5ec1-4e88-8527-95f73f70fc2c" />

After

<img width="658" height="191" alt="스크린샷 2026-05-14 오전 1 41 14" src="https://github.com/user-attachments/assets/82c0261f-6248-44bd-8693-f892ecf79efe" />


## 💬 리뷰어에게

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.