### PR TITLE
fix: PC 환경에서 앱 프레임이 흔들리는 현상 수정

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -41,6 +41,7 @@
 
   body {
     @apply bg-semantic-system-white text-semantic-object-boldest;
+    scrollbar-gutter: stable;
   }
 
   :focus-visible {


### PR DESCRIPTION
## 📌 관련 이슈

- closes #137 

## 📝 작업 내용

- [x] `body`에 `scrollbar-gutter: stable` 적용

## 🔎 자세한 설명

앱 프레임(`<main>`)과 fixed 헤더/바텀탭이 모두 `mx-auto`로 가로 중앙 정렬되어 있습니다. Windows 브라우저의 네이티브 스크롤바는 뷰포트 너비를 점유하는데, 탭 전환 시 콘텐츠 높이 변화에 따라 스크롤바가 나타났다 사라지면서 중앙 정렬 기준이 다시 계산되고 프레임 전체가 좌우로 이동하는 현상이 발생합니다. macOS에서는 스크롤바가 너비를 점유하지 않아 해당 현상이 없었습니다.

`scrollbar-gutter: stable`은 스크롤바가 없을 때도 스크롤바 자리를 항상 예약해 뷰포트 너비가 변하지 않도록 합니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

@coderabbitai ignore

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
