### PR TITLE
feat: 피드 페이지 공개 및 공유 기능 개선

### DIFF
--- a/apps/web/app/(with-tab)/feed/[id]/page.tsx
+++ b/apps/web/app/(with-tab)/feed/[id]/page.tsx
@@ -1,7 +1,8 @@
 import type { Metadata } from 'next';
 
-import { type FeedPost } from '@/entities/feed';
 import { FeedDetailPage } from '@/views/feed-detail';
+
+import { type FeedPost } from '@/entities/feed';
 
 import { serverApi } from '@/shared/api/server-api';
 

--- a/apps/web/app/(with-tab)/feed/[id]/page.tsx
+++ b/apps/web/app/(with-tab)/feed/[id]/page.tsx
@@ -1,3 +1,40 @@
+import type { Metadata } from 'next';
+
+import { type FeedPost } from '@/entities/feed';
 import { FeedDetailPage } from '@/views/feed-detail';
+
+import { serverApi } from '@/shared/api/server-api';
+
+type FeedDetailPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export async function generateMetadata({
+  params,
+}: FeedDetailPageProps): Promise<Metadata> {
+  const { id } = await params;
+
+  try {
+    const post = await serverApi.get<FeedPost>(`/feed/${id}`);
+    const thumbnail = post.postImages[0];
+    const title = `${post.title} - 플로그`;
+    const description = post.contents;
+
+    return {
+      title,
+      description,
+      openGraph: {
+        type: 'article',
+        title,
+        description,
+        images: thumbnail
+          ? [{ url: thumbnail, width: 480, height: 480, alt: post.title }]
+          : undefined,
+      },
+    };
+  } catch {
+    return {};
+  }
+}
 
 export default FeedDetailPage;

--- a/apps/web/app/(with-tab)/page.tsx
+++ b/apps/web/app/(with-tab)/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
 
 export default function Home() {
-  redirect('/map');
+  redirect('/feed');
 }

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -7,7 +7,6 @@ export function proxy(request: NextRequest) {
 
   const isProtectedPage =
     pathname.startsWith('/map') ||
-    pathname.startsWith('/feed') ||
     pathname.startsWith('/log') ||
     pathname.startsWith('/my');
 
@@ -25,11 +24,5 @@ export function proxy(request: NextRequest) {
 }
 
 export const config = {
-  matcher: [
-    '/map/:path*',
-    '/feed/:path*',
-    '/log/:path*',
-    '/my/:path*',
-    '/signup/:path*',
-  ],
+  matcher: ['/map/:path*', '/log/:path*', '/my/:path*', '/signup/:path*'],
 };

--- a/apps/web/proxy.ts
+++ b/apps/web/proxy.ts
@@ -17,7 +17,7 @@ export function proxy(request: NextRequest) {
   }
 
   if (accessToken && isGuestOnlyPage) {
-    return NextResponse.redirect(new URL('/map', request.url));
+    return NextResponse.redirect(new URL('/', request.url));
   }
 
   return NextResponse.next();

--- a/apps/web/src/features/copy-link/index.ts
+++ b/apps/web/src/features/copy-link/index.ts
@@ -1,1 +1,0 @@
-export { default as CopyLinkButton } from './ui/CopyLinkButton';

--- a/apps/web/src/features/share-post/index.ts
+++ b/apps/web/src/features/share-post/index.ts
@@ -1,0 +1,1 @@
+export { default as ShareButton } from './ui/ShareButton';

--- a/apps/web/src/features/share-post/ui/ShareButton.tsx
+++ b/apps/web/src/features/share-post/ui/ShareButton.tsx
@@ -40,7 +40,8 @@ export default function ShareButton({ postId }: ShareButtonProps) {
     try {
       const shareData = { url };
       await navigator.share(shareData);
-    } catch {
+    } catch (error) {
+      if (error instanceof DOMException && error.name === 'AbortError') return;
       toast({
         type: 'error',
         description: '공유에 실패했어요. 다시 시도해 주세요.',

--- a/apps/web/src/features/share-post/ui/ShareButton.tsx
+++ b/apps/web/src/features/share-post/ui/ShareButton.tsx
@@ -36,6 +36,7 @@ export default function ShareButton({ postId }: ShareButtonProps) {
   const handleShare = async () => {
     if (!navigator.share) {
       await handleCopy();
+      return;
     }
     try {
       const shareData = { url };

--- a/apps/web/src/features/share-post/ui/ShareButton.tsx
+++ b/apps/web/src/features/share-post/ui/ShareButton.tsx
@@ -41,7 +41,11 @@ export default function ShareButton({ postId }: ShareButtonProps) {
       const shareData = { url };
       await navigator.share(shareData);
     } catch (error) {
-      if (error instanceof DOMException && error.name === 'AbortError') return;
+      if (
+        error instanceof DOMException &&
+        (error.name === 'AbortError' || error.name === 'InvalidStateError')
+      )
+        return;
       toast({
         type: 'error',
         description: '공유에 실패했어요. 다시 시도해 주세요.',

--- a/apps/web/src/features/share-post/ui/ShareButton.tsx
+++ b/apps/web/src/features/share-post/ui/ShareButton.tsx
@@ -2,12 +2,14 @@
 
 import { Icon, useToast } from '@plog/ui';
 
-type CopyLinkButtonProps = {
+type ShareButtonProps = {
   postId: number;
 };
 
-export default function CopyLinkButton({ postId }: CopyLinkButtonProps) {
+export default function ShareButton({ postId }: ShareButtonProps) {
   const { toast } = useToast();
+
+  const url = `${window.location.origin}/feed/${postId}`;
 
   const handleCopy = async () => {
     if (!navigator.clipboard) {
@@ -17,7 +19,6 @@ export default function CopyLinkButton({ postId }: CopyLinkButtonProps) {
       });
       return;
     }
-    const url = `${window.location.origin}/feed/${postId}`;
     try {
       await navigator.clipboard.writeText(url);
       toast({
@@ -32,11 +33,26 @@ export default function CopyLinkButton({ postId }: CopyLinkButtonProps) {
     }
   };
 
+  const handleShare = async () => {
+    if (!navigator.share) {
+      await handleCopy();
+    }
+    try {
+      const shareData = { url };
+      await navigator.share(shareData);
+    } catch {
+      toast({
+        type: 'error',
+        description: '공유에 실패했어요. 다시 시도해 주세요.',
+      });
+    }
+  };
+
   return (
     <button
       type="button"
       className="flex cursor-pointer items-center"
-      onClick={handleCopy}
+      onClick={handleShare}
     >
       <Icon name="share" className="text-semantic-object-normal" />
     </button>

--- a/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
+++ b/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
@@ -16,7 +16,7 @@ import {
   Spinner,
 } from '@plog/ui';
 
-import { CopyLinkButton } from '@/features/copy-link';
+import { ShareButton } from '@/features/share-post';
 import { BookmarkButton } from '@/features/toggle-bookmark';
 import { LikeButton } from '@/features/toggle-like';
 
@@ -346,7 +346,7 @@ export default function FeedDetailCard({ postId }: { postId: string }) {
               </div>
             )}
           </div>
-          <div className="flex flex-col gap-4 px-6 pt-3">
+          <div className="flex flex-col gap-2.5 px-6 pt-3">
             {!isMyPost && (
               <div className="flex justify-between">
                 <div className="flex items-center gap-1.5">
@@ -360,16 +360,16 @@ export default function FeedDetailCard({ postId }: { postId: string }) {
                     postId={post.postId}
                     isBookmarked={post.bookMark}
                   />
-                  <CopyLinkButton postId={post.postId} />
+                  <ShareButton postId={post.postId} />
                 </div>
               </div>
             )}
-            <div className="flex flex-col gap-4">
+            <div className="flex flex-col gap-1.5">
               <div className="flex items-center justify-between">
                 <Badge variant="soft" color="orange">
                   {post.category}
                 </Badge>
-                {isMyPost && <CopyLinkButton postId={post.postId} />}
+                {isMyPost && <ShareButton postId={post.postId} />}
               </div>
               <div className="flex flex-col gap-1">
                 <span className="title-xs text-semantic-object-boldest">

--- a/apps/web/src/views/feed/ui/FeedCard.tsx
+++ b/apps/web/src/views/feed/ui/FeedCard.tsx
@@ -9,7 +9,7 @@ import { useRouter } from 'next/navigation';
 import { Avatar, Carousel, Icon } from '@plog/ui';
 import { cn } from '@plog/utils';
 
-import { CopyLinkButton } from '@/features/copy-link';
+import { ShareButton } from '@/features/share-post';
 import { BookmarkButton } from '@/features/toggle-bookmark';
 import { LikeButton } from '@/features/toggle-like';
 
@@ -205,7 +205,7 @@ export default function FeedCard({ post, isLast }: FeedCardProps) {
                 postId={post.postId}
                 isBookmarked={post.bookMark}
               />
-              <CopyLinkButton postId={post.postId} />
+              <ShareButton postId={post.postId} />
             </div>
           </div>
           <div className="flex flex-col gap-3">


### PR DESCRIPTION
## 📌 관련 이슈

- closes #135

## 📝 작업 내용

- [x] `copy-link` feature를 `share-post`로 변경, `CopyLinkButton` → `ShareButton`
- [x] `ShareButton`에 Web Share API(`navigator.share`) 추가
- [x] 피드 상세 페이지에 `generateMetadata`로 포스트별 동적 OG 메타데이터 추가
- [x] `/feed` 경로 인증 리다이렉트 제거
- [x] 루트 경로(`/`) 기본 리다이렉트를 `/feed`로 변경

## 🔎 자세한 설명

### ✅ 공유 기능 개선 및 OG 메타데이터 추가

기존 클립보드 복사 전용 버튼을 Web Share API를 우선 사용하는 방식으로 확장했습니다. `navigator.share`를 지원하지 않는 환경에서는 기존과 동일하게 클립보드 복사 방식으로 폴백됩니다.

사용자가 직접 공유 시트를 닫은 경우(`AbortError`)와 이미 공유 시트가 열린 상태에서 중복 호출된 경우(`InvalidStateError`)는 정상적인 사용자 인터랙션으로 간주해 토스트를 노출하지 않도록 처리했습니다.

또한 `/feed/[id]/page.tsx`에 Next.js `generateMetadata`를 추가해 포스트 데이터를 서버에서 fetch한 뒤 동적으로 OG 메타데이터를 생성하도록 했습니다.

### ✅ /feed 경로 인증 리다이렉트 제거 및 기본 랜딩 페이지 변경

`proxy.ts`의 `isProtectedPage`와 `matcher`에서 `/feed` 경로를 제거해 피드를 비로그인 사용자도 접근 가능한 공개 경로로 변경했습니다.

또한 루트 경로(`/`)의 기본 리다이렉트 대상을 `/map`에서 `/feed`로 수정했습니다. 이에 맞춰 로그인된 사용자가 게스트 전용 페이지에 접근했을 때의 리다이렉트 대상도 `/map` 대신 `/`로 변경했습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
