### PR TITLE
chore: 기본 OG 이미지 URL 기준을 프로덕션 URL로 수정

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -14,8 +14,8 @@ export const viewport: Viewport = {
   colorScheme: 'light',
 };
 
-const siteUrl = process.env.VERCEL_URL
-  ? `https://${process.env.VERCEL_URL}`
+const siteUrl = process.env.VERCEL_PROJECT_PRODUCTION_URL
+  ? `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`
   : 'https://localhost:3000';
 
 export const metadata: Metadata = {


### PR DESCRIPTION
## 📌 관련 이슈

- closes #145 

## 📝 작업 내용

- [x] `layout.tsx`의 `siteUrl` 구성을 `VERCEL_URL` → `VERCEL_PROJECT_PRODUCTION_URL`로 변경

## 🔎 자세한 설명

`VERCEL_URL`은 배포마다 변경되는 Preview URL이기 때문에 `metadataBase`로 사용할 경우 `og:image`가 임시 도메인을 가리키게 됩니다. 이로 인해 카카오톡 등의 크롤러가 이미지를 정상적으로 수집하지 못해 기본 OG 이미지가 표시되는 문제가 있었습니다.

반면 `VERCEL_PROJECT_PRODUCTION_URL`은 항상 동일한 프로덕션 도메인을 제공하므로, OG 이미지 URL이 안정적으로 유지되어 크롤러가 이미지를 정상적으로 가져올 수 있습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

@coderabbitai ignore

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
