### PR TITLE
fix: 마이페이지 내 기록 리스트 아이콘 수정

### DIFF
--- a/apps/web/src/views/my/ui/RecordTab.tsx
+++ b/apps/web/src/views/my/ui/RecordTab.tsx
@@ -86,7 +86,11 @@ export default function RecordTab() {
       }
       renderAction={(feed) =>
         !feed.isPublic && (
-          <Icon name="lock-filled" className="text-semantic-object-subtle" />
+          <Icon
+            name="lock-filled"
+            className="text-semantic-object-subtle"
+            aria-label="비공개 게시물"
+          />
         )
       }
     />

--- a/apps/web/src/views/my/ui/RecordTab.tsx
+++ b/apps/web/src/views/my/ui/RecordTab.tsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import { useRouter } from 'next/navigation';
 
-import { Spinner } from '@plog/ui';
+import { Icon, Spinner } from '@plog/ui';
 
 import { FeedList, type RecordTypeValue } from '@/widgets/feed-list';
 
@@ -84,15 +84,11 @@ export default function RecordTab() {
           />
         </div>
       }
-      renderAction={(feed, viewType) => (
-        <BookmarkButton
-          postId={feed.postId}
-          isBookmarked={feed.bookMark}
-          className={
-            viewType === 'grid' ? 'text-semantic-object-subtle' : undefined
-          }
-        />
-      )}
+      renderAction={(feed) =>
+        !feed.isPublic && (
+          <Icon name="lock-filled" className="text-semantic-object-subtle" />
+        )
+      }
     />
   );
 }


### PR DESCRIPTION
## 📌 관련 이슈

- closes #148 

## 📝 작업 내용

- [x] 마이페이지 내 기록 리스트 아이콘 수정

## 🔎 자세한 설명

> 왜 이렇게 변경했나요? 기술적 선택의 근거나 배경을 설명해 주세요.

### ✅ 마이페이지 내 기록 리스트 아이콘 수정

디자인 설계상 마이페이지에서는 기존 북마크 아이콘이 아닌, 비공개 상태에 맞는 자물쇠 아이콘(또는 아이콘 미노출)이 적용되어야 했지만 반영되지 않고 있어 수정했습니다.


## 🖼️ 스크린샷

> UI 변경이 있다면 Before / After 스크린샷을 첨부해 주세요.

### Before
<img width="558" height="948" alt="스크린샷 2026-05-16 오후 10 39 18" src="https://github.com/user-attachments/assets/f977f130-c9ef-4faa-8526-9d488429827a" />

### After
<img width="495" height="949" alt="스크린샷 2026-05-16 오후 10 39 22" src="https://github.com/user-attachments/assets/bd0678d2-3b5a-40a8-8143-868dc8617900" />

<img width="505" height="961" alt="스크린샷 2026-05-16 오후 10 39 25" src="https://github.com/user-attachments/assets/879bed6e-9486-48bc-84c4-cfac071df85e" />


## 💬 리뷰어에게

> 리뷰 시 집중적으로 봐줬으면 하는 부분이나 참고할 내용을 적어주세요.

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
