### PR TITLE
fix: 장소 검색 결과 리스트 스크롤 버그 수정 및 카카오맵 검색 로직 개선

### DIFF
--- a/apps/web/src/features/place-search/index.ts
+++ b/apps/web/src/features/place-search/index.ts
@@ -1,6 +1,7 @@
 export { formatRecentPlaceDate } from './model/recent-place-date';
 export type { SelectedPlace } from './model/selected-place';
 export { createSelectedPlace } from './model/selected-place';
+export type { UserCoords } from './model/types';
 export {
   useDeleteRecentPlaceMutation,
   useDeleteRecentPlacesMutation,

--- a/apps/web/src/features/place-search/model/types.ts
+++ b/apps/web/src/features/place-search/model/types.ts
@@ -1,0 +1,1 @@
+export type UserCoords = Pick<GeolocationCoordinates, 'latitude' | 'longitude'>;

--- a/apps/web/src/global.d.ts
+++ b/apps/web/src/global.d.ts
@@ -159,6 +159,23 @@ declare namespace kakao.maps {
       totalCount: number;
     }
 
+    type SortBy = 'ACCURACY' | 'DISTANCE';
+
+    interface PlacesSearchOptions {
+      category_group_code?: string;
+      location?: LatLng;
+      x?: number;
+      y?: number;
+      radius?: number;
+      bounds?: LatLngBounds;
+      rect?: string;
+      size?: number;
+      page?: number;
+      sort?: SortBy;
+      useMapCenter?: boolean;
+      useMapBounds?: boolean;
+    }
+
     type PlacesSearchCallback = (
       data: PlacesSearchResultItem[],
       status: Status,
@@ -166,13 +183,22 @@ declare namespace kakao.maps {
     ) => void;
 
     class Places {
-      keywordSearch(keyword: string, callback: PlacesSearchCallback): void;
+      keywordSearch(
+        keyword: string,
+        callback: PlacesSearchCallback,
+        options?: PlacesSearchOptions,
+      ): void;
     }
 
     const Status: {
       OK: 'OK';
       ZERO_RESULT: 'ZERO_RESULT';
       ERROR: 'ERROR';
+    };
+
+    const SortBy: {
+      ACCURACY: 'ACCURACY';
+      DISTANCE: 'DISTANCE';
     };
   }
 }

--- a/apps/web/src/views/log/lib/use-kakao-place-search.ts
+++ b/apps/web/src/views/log/lib/use-kakao-place-search.ts
@@ -10,7 +10,10 @@ import { type SearchState } from '@/widgets/place-search';
 
 import { type UserCoords } from '@/features/place-search';
 
+import { useDebounce } from '@/shared/lib/debounce';
+
 const MIN_SEARCH_LENGTH = 1;
+const SEARCH_DEBOUNCE_DELAY = 300;
 
 export function useKakaoPlaceSearch(
   sdkLoaded: boolean,
@@ -30,7 +33,8 @@ export function useKakaoPlaceSearch(
   const latitude = userCoords?.latitude;
   const longitude = userCoords?.longitude;
   const trimmedQuery = query.trim();
-  const canSearch = sdkLoaded && trimmedQuery.length >= MIN_SEARCH_LENGTH;
+  const debouncedQuery = useDebounce(trimmedQuery, SEARCH_DEBOUNCE_DELAY);
+  const canSearch = sdkLoaded && debouncedQuery.length >= MIN_SEARCH_LENGTH;
 
   const resetPagination = useCallback(() => {
     setHasNextPage(false);
@@ -43,58 +47,49 @@ export function useKakaoPlaceSearch(
     if (!canSearch) return;
 
     let canceled = false;
+    const kakaoMaps = window.kakao?.maps;
 
-    const timerId = window.setTimeout(() => {
-      if (!window.kakao?.maps?.services) {
-        setPlaces([]);
-        setSearchState('error');
-        resetPagination();
-        return;
-      }
+    if (!kakaoMaps?.services) return;
 
-      const placesService = new window.kakao.maps.services.Places();
-      const searchOptions: kakao.maps.services.PlacesSearchOptions | undefined =
-        latitude !== undefined && longitude !== undefined
-          ? {
-              location: new window.kakao.maps.LatLng(latitude, longitude),
-              sort: window.kakao.maps.services.SortBy.DISTANCE,
-            }
-          : undefined;
-
-      placesService.keywordSearch(
-        trimmedQuery,
-        (data, status, pagination) => {
-          if (canceled) return;
-
-          if (status === window.kakao?.maps.services.Status.OK) {
-            setPlaces((prevPlaces) =>
-              pagination.current === 1 ? data : [...prevPlaces, ...data],
-            );
-            setSearchState(data.length > 0 ? 'success' : 'empty');
-            setHasNextPage(pagination.hasNextPage);
-            setIsFetchingNextPage(false);
-            isFetchingNextPageRef.current = false;
-            paginationRef.current = pagination;
-            return;
+    const placesService = new kakaoMaps.services.Places();
+    const searchOptions: kakao.maps.services.PlacesSearchOptions | undefined =
+      latitude !== undefined && longitude !== undefined
+        ? {
+            location: new kakaoMaps.LatLng(latitude, longitude),
+            sort: kakaoMaps.services.SortBy.DISTANCE,
           }
+        : undefined;
 
-          setPlaces([]);
-          resetPagination();
-          setSearchState(
-            status === window.kakao?.maps.services.Status.ZERO_RESULT
-              ? 'empty'
-              : 'error',
+    placesService.keywordSearch(
+      debouncedQuery,
+      (data, status, pagination) => {
+        if (canceled) return;
+
+        if (status === kakaoMaps.services.Status.OK) {
+          setPlaces((prevPlaces) =>
+            pagination.current === 1 ? data : [...prevPlaces, ...data],
           );
-        },
-        searchOptions,
-      );
-    }, 300);
+          setSearchState(data.length > 0 ? 'success' : 'empty');
+          setHasNextPage(pagination.hasNextPage);
+          setIsFetchingNextPage(false);
+          isFetchingNextPageRef.current = false;
+          paginationRef.current = pagination;
+          return;
+        }
+
+        setPlaces([]);
+        resetPagination();
+        setSearchState(
+          status === kakaoMaps.services.Status.ZERO_RESULT ? 'empty' : 'error',
+        );
+      },
+      searchOptions,
+    );
 
     return () => {
       canceled = true;
-      window.clearTimeout(timerId);
     };
-  }, [canSearch, latitude, longitude, resetPagination, trimmedQuery]);
+  }, [canSearch, debouncedQuery, latitude, longitude, resetPagination]);
 
   const handleQueryChange = (event: ChangeEvent<HTMLInputElement>) => {
     const nextQuery = event.target.value;

--- a/apps/web/src/views/log/lib/use-kakao-place-search.ts
+++ b/apps/web/src/views/log/lib/use-kakao-place-search.ts
@@ -10,7 +10,12 @@ import { type SearchState } from '@/widgets/place-search';
 
 const MIN_SEARCH_LENGTH = 1;
 
-export function useKakaoPlaceSearch(sdkLoaded: boolean) {
+type UserCoords = Pick<GeolocationCoordinates, 'latitude' | 'longitude'>;
+
+export function useKakaoPlaceSearch(
+  sdkLoaded: boolean,
+  userCoords: UserCoords | null,
+) {
   const [query, setQuery] = useState('');
   const [places, setPlaces] = useState<
     kakao.maps.services.PlacesSearchResultItem[]
@@ -42,40 +47,54 @@ export function useKakaoPlaceSearch(sdkLoaded: boolean) {
       }
 
       const placesService = new window.kakao.maps.services.Places();
+      const searchOptions: kakao.maps.services.PlacesSearchOptions | undefined =
+        userCoords
+          ? {
+              location: new window.kakao.maps.LatLng(
+                userCoords.latitude,
+                userCoords.longitude,
+              ),
+              sort: window.kakao.maps.services.SortBy.DISTANCE,
+            }
+          : undefined;
 
-      placesService.keywordSearch(trimmedQuery, (data, status, pagination) => {
-        if (canceled) return;
+      placesService.keywordSearch(
+        trimmedQuery,
+        (data, status, pagination) => {
+          if (canceled) return;
 
-        if (status === window.kakao?.maps.services.Status.OK) {
-          setPlaces((prevPlaces) =>
-            pagination.current === 1 ? data : [...prevPlaces, ...data],
-          );
-          setSearchState(data.length > 0 ? 'success' : 'empty');
-          setHasNextPage(pagination.hasNextPage);
+          if (status === window.kakao?.maps.services.Status.OK) {
+            setPlaces((prevPlaces) =>
+              pagination.current === 1 ? data : [...prevPlaces, ...data],
+            );
+            setSearchState(data.length > 0 ? 'success' : 'empty');
+            setHasNextPage(pagination.hasNextPage);
+            setIsFetchingNextPage(false);
+            isFetchingNextPageRef.current = false;
+            paginationRef.current = pagination;
+            return;
+          }
+
+          setPlaces([]);
+          setHasNextPage(false);
           setIsFetchingNextPage(false);
           isFetchingNextPageRef.current = false;
-          paginationRef.current = pagination;
-          return;
-        }
-
-        setPlaces([]);
-        setHasNextPage(false);
-        setIsFetchingNextPage(false);
-        isFetchingNextPageRef.current = false;
-        paginationRef.current = null;
-        setSearchState(
-          status === window.kakao?.maps.services.Status.ZERO_RESULT
-            ? 'empty'
-            : 'error',
-        );
-      });
+          paginationRef.current = null;
+          setSearchState(
+            status === window.kakao?.maps.services.Status.ZERO_RESULT
+              ? 'empty'
+              : 'error',
+          );
+        },
+        searchOptions,
+      );
     }, 300);
 
     return () => {
       canceled = true;
       window.clearTimeout(timerId);
     };
-  }, [canSearch, trimmedQuery]);
+  }, [canSearch, trimmedQuery, userCoords]);
 
   const handleQueryChange = (event: ChangeEvent<HTMLInputElement>) => {
     const nextQuery = event.target.value;

--- a/apps/web/src/views/log/lib/use-kakao-place-search.ts
+++ b/apps/web/src/views/log/lib/use-kakao-place-search.ts
@@ -27,6 +27,8 @@ export function useKakaoPlaceSearch(
   const paginationRef = useRef<kakao.maps.services.Pagination | null>(null);
   const isFetchingNextPageRef = useRef(false);
 
+  const latitude = userCoords?.latitude;
+  const longitude = userCoords?.longitude;
   const trimmedQuery = query.trim();
   const canSearch = sdkLoaded && trimmedQuery.length >= MIN_SEARCH_LENGTH;
 
@@ -52,12 +54,9 @@ export function useKakaoPlaceSearch(
 
       const placesService = new window.kakao.maps.services.Places();
       const searchOptions: kakao.maps.services.PlacesSearchOptions | undefined =
-        userCoords
+        latitude !== undefined && longitude !== undefined
           ? {
-              location: new window.kakao.maps.LatLng(
-                userCoords.latitude,
-                userCoords.longitude,
-              ),
+              location: new window.kakao.maps.LatLng(latitude, longitude),
               sort: window.kakao.maps.services.SortBy.DISTANCE,
             }
           : undefined;
@@ -95,7 +94,7 @@ export function useKakaoPlaceSearch(
       canceled = true;
       window.clearTimeout(timerId);
     };
-  }, [canSearch, resetPagination, trimmedQuery, userCoords]);
+  }, [canSearch, latitude, longitude, resetPagination, trimmedQuery]);
 
   const handleQueryChange = (event: ChangeEvent<HTMLInputElement>) => {
     const nextQuery = event.target.value;

--- a/apps/web/src/views/log/lib/use-kakao-place-search.ts
+++ b/apps/web/src/views/log/lib/use-kakao-place-search.ts
@@ -8,9 +8,9 @@ import {
 
 import { type SearchState } from '@/widgets/place-search';
 
-const MIN_SEARCH_LENGTH = 1;
+import { type UserCoords } from '@/features/place-search';
 
-type UserCoords = Pick<GeolocationCoordinates, 'latitude' | 'longitude'>;
+const MIN_SEARCH_LENGTH = 1;
 
 export function useKakaoPlaceSearch(
   sdkLoaded: boolean,

--- a/apps/web/src/views/log/lib/use-kakao-place-search.ts
+++ b/apps/web/src/views/log/lib/use-kakao-place-search.ts
@@ -1,4 +1,10 @@
-import { type ChangeEvent, useEffect, useState } from 'react';
+import {
+  type ChangeEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import { type SearchState } from '@/widgets/place-search';
 
@@ -10,6 +16,11 @@ export function useKakaoPlaceSearch(sdkLoaded: boolean) {
     kakao.maps.services.PlacesSearchResultItem[]
   >([]);
   const [searchState, setSearchState] = useState<SearchState>('idle');
+  const [hasNextPage, setHasNextPage] = useState(false);
+  const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
+
+  const paginationRef = useRef<kakao.maps.services.Pagination | null>(null);
+  const isFetchingNextPageRef = useRef(false);
 
   const trimmedQuery = query.trim();
   const canSearch = sdkLoaded && trimmedQuery.length >= MIN_SEARCH_LENGTH;
@@ -23,21 +34,35 @@ export function useKakaoPlaceSearch(sdkLoaded: boolean) {
       if (!window.kakao?.maps?.services) {
         setPlaces([]);
         setSearchState('error');
+        setHasNextPage(false);
+        setIsFetchingNextPage(false);
+        isFetchingNextPageRef.current = false;
+        paginationRef.current = null;
         return;
       }
 
       const placesService = new window.kakao.maps.services.Places();
 
-      placesService.keywordSearch(trimmedQuery, (data, status) => {
+      placesService.keywordSearch(trimmedQuery, (data, status, pagination) => {
         if (canceled) return;
 
         if (status === window.kakao?.maps.services.Status.OK) {
-          setPlaces(data);
+          setPlaces((prevPlaces) =>
+            pagination.current === 1 ? data : [...prevPlaces, ...data],
+          );
           setSearchState(data.length > 0 ? 'success' : 'empty');
+          setHasNextPage(pagination.hasNextPage);
+          setIsFetchingNextPage(false);
+          isFetchingNextPageRef.current = false;
+          paginationRef.current = pagination;
           return;
         }
 
         setPlaces([]);
+        setHasNextPage(false);
+        setIsFetchingNextPage(false);
+        isFetchingNextPageRef.current = false;
+        paginationRef.current = null;
         setSearchState(
           status === window.kakao?.maps.services.Status.ZERO_RESULT
             ? 'empty'
@@ -58,6 +83,10 @@ export function useKakaoPlaceSearch(sdkLoaded: boolean) {
     if (nextQuery.trim().length < MIN_SEARCH_LENGTH) {
       setPlaces([]);
       setSearchState('idle');
+      setHasNextPage(false);
+      setIsFetchingNextPage(false);
+      isFetchingNextPageRef.current = false;
+      paginationRef.current = null;
     } else {
       setSearchState('loading');
     }
@@ -67,7 +96,30 @@ export function useKakaoPlaceSearch(sdkLoaded: boolean) {
     setQuery('');
     setPlaces([]);
     setSearchState('idle');
+    setHasNextPage(false);
+    setIsFetchingNextPage(false);
+    isFetchingNextPageRef.current = false;
+    paginationRef.current = null;
   };
 
-  return { query, places, searchState, handleQueryChange, handleClearQuery };
+  const loadNextPage = useCallback(() => {
+    if (!paginationRef.current?.hasNextPage || isFetchingNextPageRef.current) {
+      return;
+    }
+
+    isFetchingNextPageRef.current = true;
+    setIsFetchingNextPage(true);
+    paginationRef.current.nextPage();
+  }, []);
+
+  return {
+    query,
+    places,
+    searchState,
+    hasNextPage,
+    isFetchingNextPage,
+    loadNextPage,
+    handleQueryChange,
+    handleClearQuery,
+  };
 }

--- a/apps/web/src/views/log/lib/use-kakao-place-search.ts
+++ b/apps/web/src/views/log/lib/use-kakao-place-search.ts
@@ -30,6 +30,13 @@ export function useKakaoPlaceSearch(
   const trimmedQuery = query.trim();
   const canSearch = sdkLoaded && trimmedQuery.length >= MIN_SEARCH_LENGTH;
 
+  const resetPagination = useCallback(() => {
+    setHasNextPage(false);
+    setIsFetchingNextPage(false);
+    isFetchingNextPageRef.current = false;
+    paginationRef.current = null;
+  }, []);
+
   useEffect(() => {
     if (!canSearch) return;
 
@@ -39,10 +46,7 @@ export function useKakaoPlaceSearch(
       if (!window.kakao?.maps?.services) {
         setPlaces([]);
         setSearchState('error');
-        setHasNextPage(false);
-        setIsFetchingNextPage(false);
-        isFetchingNextPageRef.current = false;
-        paginationRef.current = null;
+        resetPagination();
         return;
       }
 
@@ -76,10 +80,7 @@ export function useKakaoPlaceSearch(
           }
 
           setPlaces([]);
-          setHasNextPage(false);
-          setIsFetchingNextPage(false);
-          isFetchingNextPageRef.current = false;
-          paginationRef.current = null;
+          resetPagination();
           setSearchState(
             status === window.kakao?.maps.services.Status.ZERO_RESULT
               ? 'empty'
@@ -94,7 +95,7 @@ export function useKakaoPlaceSearch(
       canceled = true;
       window.clearTimeout(timerId);
     };
-  }, [canSearch, trimmedQuery, userCoords]);
+  }, [canSearch, resetPagination, trimmedQuery, userCoords]);
 
   const handleQueryChange = (event: ChangeEvent<HTMLInputElement>) => {
     const nextQuery = event.target.value;
@@ -102,10 +103,7 @@ export function useKakaoPlaceSearch(
     if (nextQuery.trim().length < MIN_SEARCH_LENGTH) {
       setPlaces([]);
       setSearchState('idle');
-      setHasNextPage(false);
-      setIsFetchingNextPage(false);
-      isFetchingNextPageRef.current = false;
-      paginationRef.current = null;
+      resetPagination();
     } else {
       setSearchState('loading');
     }
@@ -115,10 +113,7 @@ export function useKakaoPlaceSearch(
     setQuery('');
     setPlaces([]);
     setSearchState('idle');
-    setHasNextPage(false);
-    setIsFetchingNextPage(false);
-    isFetchingNextPageRef.current = false;
-    paginationRef.current = null;
+    resetPagination();
   };
 
   const loadNextPage = useCallback(() => {

--- a/apps/web/src/views/log/ui/PlaceSearchOverlay.tsx
+++ b/apps/web/src/views/log/ui/PlaceSearchOverlay.tsx
@@ -20,6 +20,7 @@ import {
 } from '@/features/place-search';
 
 import { KAKAO_MAP_SDK_URL } from '@/shared/api/constants';
+import { useUserLocation } from '@/shared/lib/geolocation';
 import { useScrollLock } from '@/shared/lib/scroll-lock';
 import {
   FetchErrorEmptyState,
@@ -49,6 +50,9 @@ export default function PlaceSearchOverlay({
 }: PlaceSearchOverlayProps) {
   const [sdkLoaded, setSdkLoaded] = useState(false);
   const [sdkLoadError, setSdkLoadError] = useState(false);
+  const [userCoords, setUserCoords] = useState<GeolocationCoordinates | null>(
+    null,
+  );
   const resultScrollRef = useRef<HTMLDivElement>(null);
 
   const {
@@ -60,7 +64,7 @@ export default function PlaceSearchOverlay({
     loadNextPage,
     handleQueryChange,
     handleClearQuery,
-  } = useKakaoPlaceSearch(sdkLoaded);
+  } = useKakaoPlaceSearch(sdkLoaded, userCoords);
   const { data: recentPlaces = [] } = useRecentPlacesQuery();
   const saveRecentPlaceMutation = useSaveRecentPlaceMutation();
   const deleteRecentPlaceMutation = useDeleteRecentPlaceMutation();
@@ -69,6 +73,9 @@ export default function PlaceSearchOverlay({
   const { toast } = useToast();
 
   useScrollLock();
+  useUserLocation((coords) => {
+    setUserCoords(coords);
+  });
 
   const displayState = sdkLoadError ? 'error' : searchState;
 

--- a/apps/web/src/views/log/ui/PlaceSearchOverlay.tsx
+++ b/apps/web/src/views/log/ui/PlaceSearchOverlay.tsx
@@ -15,6 +15,7 @@ import {
   type SelectedPlace,
   useDeleteRecentPlaceMutation,
   useDeleteRecentPlacesMutation,
+  type UserCoords,
   useRecentPlacesQuery,
   useSaveRecentPlaceMutation,
 } from '@/features/place-search';
@@ -52,9 +53,7 @@ export default function PlaceSearchOverlay({
 }: PlaceSearchOverlayProps) {
   const [sdkLoaded, setSdkLoaded] = useState(false);
   const [sdkLoadError, setSdkLoadError] = useState(false);
-  const [userCoords, setUserCoords] = useState<GeolocationCoordinates | null>(
-    null,
-  );
+  const [userCoords, setUserCoords] = useState<UserCoords | null>(null);
   const resultScrollRef = useRef<HTMLDivElement>(null);
 
   const {

--- a/apps/web/src/views/log/ui/PlaceSearchOverlay.tsx
+++ b/apps/web/src/views/log/ui/PlaceSearchOverlay.tsx
@@ -116,7 +116,7 @@ export default function PlaceSearchOverlay({
         onReady={handleKakaoReady}
         onError={() => setSdkLoadError(true)}
       />
-      <section className="flex min-h-[calc(100dvh-var(--spacing-header))] flex-col bg-semantic-bg-standard pt-[var(--spacing-header)]">
+      <section className="flex h-dvh flex-col bg-semantic-bg-standard pt-[var(--spacing-header)]">
         <div className="sticky top-[var(--spacing-header)] z-10 border-b border-semantic-stroke-subtler bg-semantic-bg-standard px-6 py-6">
           <PlaceSearchInput
             value={query}
@@ -124,7 +124,7 @@ export default function PlaceSearchOverlay({
             onClear={handleClearQuery}
           />
         </div>
-        <div className="flex flex-1 flex-col">
+        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
           <PlaceSearchContent
             state={displayState}
             resultList={

--- a/apps/web/src/views/log/ui/PlaceSearchOverlay.tsx
+++ b/apps/web/src/views/log/ui/PlaceSearchOverlay.tsx
@@ -31,6 +31,8 @@ import {
 import { useKakaoPlaceSearch } from '../lib/use-kakao-place-search';
 import PlaceSearchResultList from './PlaceSearchResultList';
 
+const BOTTOM_NAV_HEIGHT = 80;
+
 function CenteredView({ children }: { children: ReactNode }) {
   return (
     <div className="flex flex-1 items-center justify-center bg-semantic-bg-deep p-6">
@@ -94,7 +96,7 @@ export default function PlaceSearchOverlay({
     const { scrollTop, scrollHeight, clientHeight } = scrollContainer;
     const distanceToBottom = scrollHeight - scrollTop - clientHeight;
 
-    if (distanceToBottom <= 80) {
+    if (distanceToBottom <= BOTTOM_NAV_HEIGHT) {
       loadNextPage();
     }
   }, [displayState, hasNextPage, isFetchingNextPage, loadNextPage]);

--- a/apps/web/src/views/log/ui/PlaceSearchOverlay.tsx
+++ b/apps/web/src/views/log/ui/PlaceSearchOverlay.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type ReactNode, useCallback, useState } from 'react';
+import { type ReactNode, useCallback, useRef, useState } from 'react';
 
 import Script from 'next/script';
 
@@ -49,9 +49,18 @@ export default function PlaceSearchOverlay({
 }: PlaceSearchOverlayProps) {
   const [sdkLoaded, setSdkLoaded] = useState(false);
   const [sdkLoadError, setSdkLoadError] = useState(false);
+  const resultScrollRef = useRef<HTMLDivElement>(null);
 
-  const { query, places, searchState, handleQueryChange, handleClearQuery } =
-    useKakaoPlaceSearch(sdkLoaded);
+  const {
+    query,
+    places,
+    searchState,
+    hasNextPage,
+    isFetchingNextPage,
+    loadNextPage,
+    handleQueryChange,
+    handleClearQuery,
+  } = useKakaoPlaceSearch(sdkLoaded);
   const { data: recentPlaces = [] } = useRecentPlacesQuery();
   const saveRecentPlaceMutation = useSaveRecentPlaceMutation();
   const deleteRecentPlaceMutation = useDeleteRecentPlaceMutation();
@@ -66,6 +75,22 @@ export default function PlaceSearchOverlay({
   const handleKakaoReady = useCallback(() => {
     window.kakao?.maps.load(() => setSdkLoaded(true));
   }, []);
+
+  const handleResultScroll = useCallback(() => {
+    if (displayState !== 'success' || !hasNextPage || isFetchingNextPage) {
+      return;
+    }
+
+    const scrollContainer = resultScrollRef.current;
+    if (!scrollContainer) return;
+
+    const { scrollTop, scrollHeight, clientHeight } = scrollContainer;
+    const distanceToBottom = scrollHeight - scrollTop - clientHeight;
+
+    if (distanceToBottom <= 80) {
+      loadNextPage();
+    }
+  }, [displayState, hasNextPage, isFetchingNextPage, loadNextPage]);
 
   const saveAndSelect = async (place: SelectedPlace) => {
     try {
@@ -124,7 +149,11 @@ export default function PlaceSearchOverlay({
             onClear={handleClearQuery}
           />
         </div>
-        <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+        <div
+          ref={resultScrollRef}
+          className="flex min-h-0 flex-1 flex-col overflow-y-auto"
+          onScroll={handleResultScroll}
+        >
           <PlaceSearchContent
             state={displayState}
             resultList={


### PR DESCRIPTION
## 📌 관련 이슈

- closes #151 

## 📝 작업 내용

- [x] 장소 검색 결과 리스트 `y축` 스크롤 적용
- [x] 카카오맵 SDK API 검색 결과 리스트 무한 스크롤 적용
- [x] 현재 위치 기반 장소 검색 결과 정렬 적용

## 🔎 자세한 설명

> 왜 이렇게 변경했나요? 기술적 선택의 근거나 배경을 설명해 주세요.

### ✅ 장소 검색 결과 리스트 `y축` 스크롤 적용

장소 검색 결과가 많아졌을 때 검색 모달 내부가 아닌 모달 바깥 영역이 스크롤되는 문제가 있었습니다.

확인 결과, 검색 결과 리스트 영역이 별도의 스크롤 컨테이너로 동작하지 않고 있었고, 결과 리스트를 감싸는 부모 영역에도 스크롤 가능한 높이 제약이 충분히 잡혀 있지 않았습니다.

이를 해결하기 위해 검색 결과를 감싸는 부모 영역이 남은 높이를 차지하도록 구성하고, 해당 영역에 `overflow-y-auto`를 적용했습니다. 이로써 검색바는 상단에 유지되고, 검색 결과 리스트만 `y축`으로 스크롤되도록 변경했습니다.

### ✅ 카카오맵 SDK API 검색 결과 리스트 무한 스크롤 적용

기존에는 카카오맵 SDK의 `Places.keywordSearch` 호출 결과 중 첫 번째 페이지의 데이터만 화면에 표시되었습니다. 검색 결과가 여러 페이지로 나뉘어 제공되는 경우 사용자가 이후 결과를 확인할 수 없었습니다.

카카오맵 SDK는 `keywordSearch` 콜백 함수의 세 번째 인자로 `pagination` 객체를 제공합니다. 이 객체의 `hasNextPage`와 `nextPage()`를 활용해 다음 페이지를 요청할 수 있습니다.

검색 결과 스크롤 영역이 하단에 도달했을 때 `pagination.hasNextPage`가 `true`이면 `pagination.nextPage()`를 호출하도록 구현했습니다. 이후 다음 페이지 응답이 도착하면 기존 검색 결과 뒤에 새 결과를 append하여 무한 스크롤처럼 동작하도록 처리했습니다.

```ts
placesService.keywordSearch(trimmedQuery, (data, status, pagination) => {
  if (canceled) return;

  if (status === window.kakao?.maps.services.Status.OK) {
    setPlaces((prevPlaces) =>
      pagination.current === 1 ? data : [...prevPlaces, ...data],
    );
    setSearchState(data.length > 0 ? 'success' : 'empty');
    setHasNextPage(pagination.hasNextPage);
    setIsFetchingNextPage(false);
    isFetchingNextPageRef.current = false;
    paginationRef.current = pagination;
    return;
  }

  // ...
});
```
### ✅  현재 위치 기반 장소 검색 결과 정렬 적용

장소 검색은 사용자가 현재 있거나 방문한 장소를 선택하는 흐름이기 때문에, 동일한 키워드에 대해 현재 위치와 가까운 장소가 먼저 노출되는 것이 더 자연스럽다고 판단했습니다.

이를 위해 프로젝트에서 이미 사용 중인 `useUserLocation` 훅을 재사용해 사용자의 현재 좌표를 가져오고, 좌표가 있는 경우 카카오맵 SDK의 `Places.keywordSearch` 옵션에 `location`과 `sort`를 함께 전달했습니다.

카카오맵 SDK에서 거리순 정렬을 사용하려면 `sort: kakao.maps.services.SortBy.DISTANCE`만 전달하는 것이 아니라, 기준 좌표인 `location`도 함께 전달해야 합니다.

```tsx
const searchOptions: kakao.maps.services.PlacesSearchOptions | undefined =
  userCoords
    ? {
        location: new window.kakao.maps.LatLng(
          userCoords.latitude,
          userCoords.longitude,
        ),
        sort: window.kakao.maps.services.SortBy.DISTANCE,
      }
    : undefined;
```
위치 권한이 허용되었거나 현재 좌표를 정상적으로 가져온 경우에는 현재 위치 기준 가까운 순으로 검색 결과를 보여줍니다. 반대로 위치 정보를 가져오지 못한 경우에는 `searchOptions`를 전달하지 않아 기존과 동일하게 정확도순 검색이 유지되도록 fallback 처리했습니다.

## 🖼️ 스크린샷

> UI 변경이 있다면 Before / After 스크린샷을 첨부해 주세요.

<img width="583" height="720" alt="검색 결과 무한 스크롤" src="https://github.com/user-attachments/assets/b4cc79bc-81ee-4968-a261-3435e4eda8b1" />

## 💬 리뷰어에게

> 리뷰 시 집중적으로 봐줬으면 하는 부분이나 참고할 내용을 적어주세요.

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
