### PR TITLE
fix: scrollbar-gutter 속성이 제대로 적용되지 않던 문제 수정

### DIFF
--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -35,13 +35,16 @@
 }
 
 @layer base {
+  html {
+    scrollbar-gutter: stable;
+  }
+
   :root {
     color-scheme: light;
   }
 
   body {
     @apply bg-semantic-system-white text-semantic-object-boldest;
-    scrollbar-gutter: stable;
   }
 
   :focus-visible {

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -41,6 +41,7 @@
 
   body {
     @apply bg-semantic-system-white text-semantic-object-boldest;
+    scrollbar-gutter: stable;
   }
 
   :focus-visible {


### PR DESCRIPTION
## 📌 관련 이슈

- closes #137

## 📝 작업 내용

- [x] scrollbar-gutter 속성을 body에서 html로 이동

## 🔎 자세한 설명

뷰포트 스크롤바는 `body`가 아닌 `html`(루트 요소)에 귀속되기 때문에, `body`에 선언했을 때 거터가 실제로 예약되지 않아 레이아웃 시프트가 계속 발생했습니다. 해당 속성 선언을 `html`으로 옮겨 의도대로 동작하도록 수정했습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게
@coderabbitai ignore

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
