### PR TITLE
fix: `FeedPost` scope 타입 `optional` 처리

### DIFF
--- a/apps/web/src/entities/feed/model/types.ts
+++ b/apps/web/src/entities/feed/model/types.ts
@@ -38,7 +38,7 @@ export type FeedPost = {
   address?: string;
   isPublic?: boolean;
   isAuthor?: boolean;
-  scope: PostScope;
+  scope?: PostScope;
 };
 
 export type FeedPage = {


### PR DESCRIPTION
## 📌 관련 이슈

- closes #155 

## 📝 작업 내용

- [x] `scope` 타입 `optional` 처리 

## 🔎 자세한 설명

> 왜 이렇게 변경했나요? 기술적 선택의 근거나 배경을 설명해 주세요.

### ✅ `scope` 타입 `optional` 처리 

`FeedPost` 타입 스키마에 `scope`를 추가하는 과정에서 선택적 프로퍼티로 지정하지 않아, 해당 타입을 사용하는 다른 변수에서 타입 오류가 발생했습니다.

이로 인해 Vercel 배포 과정에서 빌드가 실패하여, `scope`를 optional 프로퍼티로 수정했습니다.

## 🖼️ 스크린샷

> UI 변경이 있다면 Before / After 스크린샷을 첨부해 주세요.

## 💬 리뷰어에게

> 리뷰 시 집중적으로 봐줬으면 하는 부분이나 참고할 내용을 적어주세요.

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
