### PR TITLE
fix: PrivacySettingSection의 scope를 'PRIVATE'으로 변경

### DIFF
--- a/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
+++ b/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
@@ -378,7 +378,7 @@ export default function FeedDetailCard({ postId }: { postId: string }) {
         </div>
         {isPrivate && (
           <div className="px-6 pb-bottom-tab">
-            <PrivacySettingSection scope={post.scope} />
+            <PrivacySettingSection scope="PRIVATE" />
           </div>
         )}
       </section>


### PR DESCRIPTION
## 📌 관련 이슈

- closes #155 

## 📝 작업 내용

- [x] `PrivacySettingSection` 컴포넌트 `scope`속성을 명시적으로 전달하도록 수정

## 🔎 자세한 설명

### ✅ `PrivacySettingSection` 컴포넌트에 `scope` 값을 명시적으로 전달하도록 수정

`scope`가 optional 속성으로 변경되면서 피드 상세 화면에서 `post.scope` 전달 시 타입 에러가 발생했습니다.

피드 상세의 `PrivacySettingSection`은 비공개 게시글일 때만 렌더링되므로, `scope="PRIVATE"`를 명시적으로 전달하여 타입 에러를 해결하였습니다. 

## 🖼️ 스크린샷

> UI 변경이 있다면 Before / After 스크린샷을 첨부해 주세요.

## 💬 리뷰어에게

> 리뷰 시 집중적으로 봐줬으면 하는 부분이나 참고할 내용을 적어주세요.

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
