### PR TITLE
feat: 마이페이지 배지 탭 구현

### DIFF
--- a/apps/web/src/entities/feed/index.ts
+++ b/apps/web/src/entities/feed/index.ts
@@ -1,7 +1,7 @@
 export { getFeedProfileView, getFeedProfileViewPosts } from './api/client';
 export {
+  formatDate,
   formatLikeCount,
-  formatStudyDate,
   formatStudyDuration,
   formatStudyDurationShort,
   formatTimeAgo,

--- a/apps/web/src/entities/feed/lib/format.ts
+++ b/apps/web/src/entities/feed/lib/format.ts
@@ -29,7 +29,7 @@ export function formatTimeAgo(time: Date | string | number) {
   return `${yearDiff}년 전`;
 }
 
-export function formatStudyDate(time: Date | string | number) {
+export function formatDate(time: Date | string | number) {
   const date = new Date(time);
   if (Number.isNaN(date.getTime())) return null;
 

--- a/apps/web/src/entities/user/model/queries.ts
+++ b/apps/web/src/entities/user/model/queries.ts
@@ -10,6 +10,7 @@ export const mypageQueryKeys = {
     ['mypage', 'posts', sort, tags] as const,
   bookmarks: (sort: string, tags: readonly string[]) =>
     ['mypage', 'bookmarks', sort, tags] as const,
+  badges: ['mypage', 'badges'] as const,
 };
 
 export function useMypageQuery() {

--- a/apps/web/src/entities/user/model/types.ts
+++ b/apps/web/src/entities/user/model/types.ts
@@ -6,6 +6,7 @@ export type UserBadge = {
   description: string;
   imageUrl: string;
   isAcquired: boolean;
+  acquiredAt: string;
 };
 
 export type TypeCardId = 'LOGI' | 'CHICHI' | 'TORI' | 'HARU' | 'POPO' | 'NAO';

--- a/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
+++ b/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
@@ -26,7 +26,7 @@ import {
   PrivacySettingSection,
   TagBadgeGroup,
 } from '@/entities/feed';
-import { formatStudyDate, formatTimeAgo } from '@/entities/feed';
+import { formatDate, formatTimeAgo } from '@/entities/feed';
 
 import { dialog } from '@/shared/lib/dialog';
 
@@ -372,7 +372,7 @@ export default function FeedDetailCard({ postId }: { postId: string }) {
               {post.contents}
             </p>
             <span className="caption-md self-end text-semantic-object-subtle">
-              {formatStudyDate(post.createAt)}
+              {formatDate(post.createAt)}
             </span>
           </div>
         </div>

--- a/apps/web/src/views/my/model/use-main-badge-mutation.ts
+++ b/apps/web/src/views/my/model/use-main-badge-mutation.ts
@@ -1,0 +1,50 @@
+import { useToast } from '@plog/ui';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { mypageQueryKeys } from '@/entities/user';
+
+import { clientApi } from '@/shared/api/client-api';
+
+function setMainBadge(badgeId: number) {
+  return clientApi.patch<string>(`/members/badge/main?badgeId=${badgeId}`);
+}
+
+function unsetMainBadge() {
+  return clientApi.delete<string>('/members/badge/main');
+}
+
+export function useSetMainBadgeMutation() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: setMainBadge,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: mypageQueryKeys.info });
+    },
+    onError: () => {
+      toast({
+        type: 'error',
+        description: '오류가 발생했어요. 다시 시도해 주세요.',
+      });
+    },
+  });
+}
+
+export function useUnsetMainBadgeMutation() {
+  const queryClient = useQueryClient();
+  const { toast } = useToast();
+
+  return useMutation({
+    mutationFn: unsetMainBadge,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: mypageQueryKeys.info });
+    },
+    onError: () => {
+      toast({
+        type: 'error',
+        description: '오류가 발생했어요. 다시 시도해 주세요.',
+      });
+    },
+  });
+}

--- a/apps/web/src/views/my/model/use-my-badges-query.ts
+++ b/apps/web/src/views/my/model/use-my-badges-query.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { mypageQueryKeys, type UserBadge } from '@/entities/user';
+
+import { clientApi } from '@/shared/api/client-api';
+
+async function fetchMyBadges() {
+  return clientApi.get<{ badges: UserBadge[] }>('/members/badge');
+}
+
+export function useMyBadgesQuery() {
+  return useQuery({
+    queryKey: mypageQueryKeys.badges,
+    queryFn: () => fetchMyBadges(),
+    select: (data) => data.badges,
+  });
+}

--- a/apps/web/src/views/my/ui/BadgeTab.tsx
+++ b/apps/web/src/views/my/ui/BadgeTab.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+import { useRef, useState } from 'react';
+
+import { Button, Dialog, Icon, Spinner, useToast } from '@plog/ui';
+import { cn } from '@plog/utils';
+
+import { formatDate } from '@/entities/feed';
+import { useMypageQuery, type UserBadge } from '@/entities/user';
+
+import { FetchErrorEmptyState } from '@/shared/ui';
+
+import {
+  useSetMainBadgeMutation,
+  useUnsetMainBadgeMutation,
+} from '../model/use-main-badge-mutation';
+import { useMyBadgesQuery } from '../model/use-my-badges-query';
+
+export default function BadgeTab() {
+  const { data: badges = [], isPending, isError, refetch } = useMyBadgesQuery();
+  const { data: mypage } = useMypageQuery();
+  const { mutate: setMainBadge, isPending: isSetting } =
+    useSetMainBadgeMutation();
+  const { mutate: unsetMainBadge, isPending: isUnsetting } =
+    useUnsetMainBadgeMutation();
+
+  const [dialogOpen, setDialogOpen] = useState(false);
+  const [selectedBadge, setSelectedBadge] = useState<UserBadge | null>(null);
+
+  const clearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const { toast } = useToast();
+
+  const mainBadge = mypage?.mainBadge ?? null;
+
+  const openBadgeDialog = (badge: UserBadge) => {
+    if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    setSelectedBadge(badge);
+    setDialogOpen(true);
+  };
+
+  const closeBadgeDialog = () => {
+    setDialogOpen(false);
+    clearTimerRef.current = setTimeout(() => setSelectedBadge(null), 200);
+  };
+
+  const handleSetMainBadge = () => {
+    if (!selectedBadge) return;
+    setMainBadge(selectedBadge.id, {
+      onSuccess: () => {
+        closeBadgeDialog();
+        toast({
+          type: 'success',
+          description: '대표 배지를 설정했어요.',
+        });
+      },
+    });
+  };
+
+  const handleUnsetMainBadge = () => {
+    unsetMainBadge(undefined, {
+      onSuccess: () => {
+        closeBadgeDialog();
+        toast({
+          type: 'success',
+          description: '대표 배지를 해제했어요.',
+        });
+      },
+    });
+  };
+
+  if (isPending) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <Spinner size="large" />
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="flex flex-1 items-center justify-center">
+        <FetchErrorEmptyState onRetry={refetch} />
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex w-full flex-col gap-12 px-6 py-8">
+        <MainBadgeSection mainBadge={mainBadge} />
+        <BadgeGrid
+          badges={badges}
+          mainBadgeId={mainBadge?.id ?? null}
+          onBadgeClick={openBadgeDialog}
+        />
+      </div>
+      <BadgeDetailDialog
+        open={dialogOpen}
+        badge={selectedBadge}
+        isMain={mainBadge?.id === selectedBadge?.id}
+        isSetting={isSetting}
+        isUnsetting={isUnsetting}
+        onClose={closeBadgeDialog}
+        onSetMain={handleSetMainBadge}
+        onUnsetMain={handleUnsetMainBadge}
+      />
+    </>
+  );
+}
+
+type MainBadgeSectionProps = {
+  mainBadge: UserBadge | null;
+};
+
+function MainBadgeSection({ mainBadge }: MainBadgeSectionProps) {
+  return (
+    <section className="flex flex-col items-center gap-4">
+      <div className="flex flex-col items-center gap-1">
+        <h2 className="title-xs text-semantic-object-boldest">
+          나의 대표 배지
+        </h2>
+        {!mainBadge && (
+          <p className="body-sm text-semantic-object-normal">
+            아직 설정한 대표 배지가 없어요.
+          </p>
+        )}
+      </div>
+      <div
+        className={cn(
+          'flex size-36 items-center justify-center overflow-hidden rounded-2xl bg-semantic-bg-deeper',
+          mainBadge &&
+            'border border-semantic-accent-normal bg-semantic-accent-subtler',
+        )}
+      >
+        {mainBadge ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={mainBadge.imageUrl}
+            alt={mainBadge.name}
+            className="size-full object-contain"
+          />
+        ) : (
+          <Icon
+            name="lock-filled"
+            size={56}
+            className="text-semantic-object-subtle"
+          />
+        )}
+      </div>
+    </section>
+  );
+}
+
+type BadgeGridProps = {
+  badges: UserBadge[];
+  mainBadgeId: number | null;
+  onBadgeClick: (badge: UserBadge) => void;
+};
+
+function BadgeGrid({ badges, mainBadgeId, onBadgeClick }: BadgeGridProps) {
+  return (
+    <section>
+      <ul className="grid grid-cols-3 gap-x-6 gap-y-4">
+        {badges.map((badge) => (
+          <BadgeItem
+            key={badge.id}
+            badge={badge}
+            isMain={mainBadgeId === badge.id}
+            onClick={badge.isAcquired ? () => onBadgeClick(badge) : undefined}
+          />
+        ))}
+      </ul>
+    </section>
+  );
+}
+
+type BadgeItemProps = {
+  badge: UserBadge;
+  isMain: boolean;
+  onClick?: () => void;
+};
+
+function BadgeItem({ badge, isMain, onClick }: BadgeItemProps) {
+  return (
+    <li className="flex flex-col items-center gap-2.5">
+      <button
+        type="button"
+        disabled={!badge.isAcquired}
+        onClick={onClick}
+        aria-label={
+          badge.isAcquired
+            ? `${badge.name} 대표 배지로 설정`
+            : `${badge.name} 잠금`
+        }
+        aria-pressed={isMain}
+        className={cn(
+          'flex aspect-square w-full items-center justify-center overflow-hidden rounded-xl transition-all',
+          badge.isAcquired && 'cursor-pointer',
+          isMain &&
+            'border border-semantic-accent-normal bg-semantic-accent-subtler',
+          !badge.isAcquired && 'cursor-default bg-semantic-bg-deeper',
+        )}
+      >
+        {badge.isAcquired ? (
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={badge.imageUrl}
+            alt={badge.name}
+            className="size-full object-contain"
+          />
+        ) : (
+          <Icon
+            name="lock-filled"
+            size={28}
+            className="text-semantic-object-subtle"
+          />
+        )}
+      </button>
+      <span className="label-md line-clamp-1 text-center text-semantic-object-boldest">
+        {badge.name}
+      </span>
+    </li>
+  );
+}
+
+type BadgeDetailDialogProps = {
+  open: boolean;
+  badge: UserBadge | null;
+  isMain: boolean;
+  isSetting: boolean;
+  isUnsetting: boolean;
+  onClose: () => void;
+  onSetMain: () => void;
+  onUnsetMain: () => void;
+};
+
+function BadgeDetailDialog({
+  open,
+  badge,
+  isMain,
+  isSetting,
+  isUnsetting,
+  onClose,
+  onSetMain,
+  onUnsetMain,
+}: BadgeDetailDialogProps) {
+  if (!badge) return;
+
+  return (
+    <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
+      <Dialog.Content>
+        <Dialog.Header>
+          <Dialog.Title>{badge.name}</Dialog.Title>
+          <Dialog.Description>
+            {formatDate(badge.acquiredAt)}
+          </Dialog.Description>
+        </Dialog.Header>
+        <Dialog.Graphic>
+          {badge?.isAcquired ? (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img
+              src={badge.imageUrl}
+              alt={badge.name}
+              width={200}
+              height={200}
+              className="object-contain"
+            />
+          ) : (
+            <div className="flex size-[200px] items-center justify-center rounded-2xl bg-semantic-bg-deeper">
+              <Icon
+                name="lock-filled"
+                size={56}
+                className="text-semantic-object-subtle"
+              />
+            </div>
+          )}
+        </Dialog.Graphic>
+        <Dialog.Description className="text-center">
+          {badge?.description}
+        </Dialog.Description>
+        <Dialog.Actions layout="vertical">
+          {isMain ? (
+            <Button
+              size="medium"
+              fullWidth
+              loading={isUnsetting}
+              onClick={onUnsetMain}
+            >
+              대표 배지 해제
+            </Button>
+          ) : (
+            badge?.isAcquired && (
+              <Button
+                size="medium"
+                fullWidth
+                loading={isSetting}
+                onClick={onSetMain}
+              >
+                대표 배지 설정
+              </Button>
+            )
+          )}
+          <Button variant="secondary" size="medium" fullWidth onClick={onClose}>
+            닫기
+          </Button>
+        </Dialog.Actions>
+      </Dialog.Content>
+    </Dialog>
+  );
+}

--- a/apps/web/src/views/my/ui/BadgeTab.tsx
+++ b/apps/web/src/views/my/ui/BadgeTab.tsx
@@ -138,7 +138,7 @@ function MainBadgeSection({ mainBadge }: MainBadgeSectionProps) {
           <img
             src={mainBadge.imageUrl}
             alt={mainBadge.name}
-            className="size-full object-contain"
+            className="object-contain"
           />
         ) : (
           <Icon

--- a/apps/web/src/views/my/ui/BadgeTab.tsx
+++ b/apps/web/src/views/my/ui/BadgeTab.tsx
@@ -38,6 +38,7 @@ export default function BadgeTab() {
   const { toast } = useToast();
 
   const mainBadge = mypage?.mainBadge ?? null;
+  const DIALOG_CLOSE_DELAY_MS = 200;
 
   const openBadgeDialog = (badge: UserBadge) => {
     if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
@@ -47,7 +48,10 @@ export default function BadgeTab() {
 
   const closeBadgeDialog = () => {
     setDialogOpen(false);
-    clearTimerRef.current = setTimeout(() => setSelectedBadge(null), 200);
+    clearTimerRef.current = setTimeout(
+      () => setSelectedBadge(null),
+      DIALOG_CLOSE_DELAY_MS,
+    );
   };
 
   const handleSetMainBadge = () => {

--- a/apps/web/src/views/my/ui/BadgeTab.tsx
+++ b/apps/web/src/views/my/ui/BadgeTab.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { Button, Dialog, Icon, Spinner, useToast } from '@plog/ui';
 import { cn } from '@plog/utils';
@@ -28,6 +28,12 @@ export default function BadgeTab() {
   const [selectedBadge, setSelectedBadge] = useState<UserBadge | null>(null);
 
   const clearTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    return () => {
+      if (clearTimerRef.current) clearTimeout(clearTimerRef.current);
+    };
+  }, []);
 
   const { toast } = useToast();
 

--- a/apps/web/src/views/my/ui/MyPage.tsx
+++ b/apps/web/src/views/my/ui/MyPage.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { AppBar, Icon, TabGroup } from '@plog/ui';
 
 import AnalysisTab from './analysis/AnalysisTab';
+import BadgeTab from './BadgeTab';
 import BookmarkTab from './BookmarkTab';
 import ProfileSection from './ProfileSection';
 import RecordTab from './RecordTab';
@@ -24,18 +25,13 @@ const TABS = [
     activeIcon: <Icon name="bookmark-filled" size={20} />,
     panel: <BookmarkTab />,
   },
-  // {
-  //   value: 'badge',
-  //   label: '뱃지',
-  //   icon: <Icon name="badge" size={20} />,
-  //   activeIcon: <Icon name="badge-filled" size={20} />,
-  //   panel: (
-  //     <div className="flex items-center justify-center py-20 text-semantic-object-subtle">
-  //       <p className="body-sm">뱃지 탭은 준비 중이에요.</p>
-  //     </div>
-  //   ),
-  //   disabled: true,
-  // },
+  {
+    value: 'badge',
+    label: '배지',
+    icon: <Icon name="badge" size={20} />,
+    activeIcon: <Icon name="badge-filled" size={20} />,
+    panel: <BadgeTab />,
+  },
   {
     value: 'analysis',
     label: '분석',


### PR DESCRIPTION
## 📌 관련 이슈

- closes #136

## 📝 작업 내용

- [x] `UserBadge.acquiredAt` 필드 추가
- [x] `badges` 쿼리 키 및 배지 조회/대표 배지 설정 및 해제 뮤테이션 연동
- [x] `BadgeTab`, `MainBadgeSection`, `BadgeGrid`, `BadgeDetailDialog` 구현
- [x] 획득/미획득 상태 분기 및 대표 배지 설정, 해제 기능 추가

## 🔎 자세한 설명

### ✅ 대표 배지 설정 및 해제 흐름

배지 그리드에서 획득한 배지를 클릭하면 `BadgeDetailDialog`가 열립니다. 현재 대표 배지 여부에 따라 대표 배지 설정 또는 대표 배지 해제 버튼이 노출되며, 뮤테이션 성공 시 `mypageQueryKeys.info` 쿼리를 무효화해 프로필 섹션에 즉시 반영되도록 처리했습니다.

미획득 배지는 잠금 아이콘과 함께 비활성화 상태로 표시되며, 다이얼로그는 획득한 배지에만 진입할 수 있습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

배지 획득 알림은 별도 이슈로 분리해 진행하겠습니다!

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
