### PR TITLE
fix: 사용자 프로필 배지 레이아웃 수정

### DIFF
--- a/apps/web/src/entities/user/ui/UserProfile.tsx
+++ b/apps/web/src/entities/user/ui/UserProfile.tsx
@@ -34,7 +34,7 @@ export default function UserProfile({
     <div className={cn('flex flex-col items-center gap-4 p-6', className)}>
       <Avatar size="small" src={profileImageUrl} alt={`${nickname} 프로필`} />
       <div className="flex flex-col items-center gap-1 text-center">
-        <div className="flex items-center gap-2">
+        <div className="relative flex items-center gap-2">
           <span className="title-md text-semantic-object-boldest">
             {nickname}
           </span>
@@ -47,7 +47,7 @@ export default function UserProfile({
               alt={mainBadge.name}
               aria-label={`${mainBadge.name}. ${mainBadge.description}`}
               title={mainBadge.description}
-              className="shrink-0"
+              className="absolute right-0 translate-x-8"
             />
           )}
         </div>

--- a/apps/web/src/entities/user/ui/UserProfile.tsx
+++ b/apps/web/src/entities/user/ui/UserProfile.tsx
@@ -42,8 +42,8 @@ export default function UserProfile({
             // eslint-disable-next-line @next/next/no-img-element
             <img
               src={mainBadge.imageUrl}
-              width={24}
-              height={24}
+              width={28}
+              height={28}
               alt={mainBadge.name}
               aria-label={`${mainBadge.name}. ${mainBadge.description}`}
               title={mainBadge.description}


### PR DESCRIPTION
## 📌 관련 이슈

- closes #159 

## 📝 작업 내용

- [x] 사용자 프로필 배지 레이아웃 수정

## 🔎 자세한 설명

> 왜 이렇게 변경했나요? 기술적 선택의 근거나 배경을 설명해 주세요.

### ✅ 사용자 프로필 배지 레이아웃 수정
기존 배지는 닉네임과 함께 `flex` 레이아웃으로 배치되어 있어, 배지가 렌더링될 경우 닉네임 영역이 밀리며 디자인 시안과 다른 UI가 표시되고 있었습니다. 배지를 `absolute`로 배치하여 레이아웃 변화 없이 고정된 위치에 렌더링되도록 수정했습니다.

## 🖼️ 스크린샷

> UI 변경이 있다면 Before / After 스크린샷을 첨부해 주세요.

### Before 

<img width="374" height="264" alt="image" src="https://github.com/user-attachments/assets/efb4cdba-bf0d-4497-9497-34bf16cc3837" />

### After
<img width="374" height="264" alt="image" src="https://github.com/user-attachments/assets/a6b4cefe-dfd8-42c9-9e35-194e23c914d7" />

## 💬 리뷰어에게

> 리뷰 시 집중적으로 봐줬으면 하는 부분이나 참고할 내용을 적어주세요.

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
