### PR TITLE
fix: 본인 게시글 액션 버튼 노출 정책 및 UI 수정

### DIFF
--- a/apps/web/src/entities/feed/ui/FeedGridItem.tsx
+++ b/apps/web/src/entities/feed/ui/FeedGridItem.tsx
@@ -44,7 +44,7 @@ export default function FeedGridItem({
           height={208}
           className="aspect-square w-full object-cover"
         />
-        <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0.6)_0%,rgba(0,0,0,0)_100%)]" />
+        <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0.3)_0%,rgba(0,0,0,0)_100%)]" />
         <div className="absolute inset-x-3 top-3 flex items-start justify-between">
           <div className="mt-1 flex items-center gap-1 text-semantic-object-subtler [&_path]:fill-semantic-object-subtler">
             <Icon name="clock" size={16} />

--- a/apps/web/src/entities/feed/ui/FeedListItem.tsx
+++ b/apps/web/src/entities/feed/ui/FeedListItem.tsx
@@ -15,12 +15,14 @@ type FeedListItemProps = {
   feed: FeedPost;
   onClick?: () => void;
   action?: ReactNode;
+  thumbnailBadge?: ReactNode;
 };
 
 export default function FeedListItem({
   feed,
   onClick,
   action,
+  thumbnailBadge,
 }: FeedListItemProps) {
   return (
     <div
@@ -47,6 +49,10 @@ export default function FeedListItem({
           sizes="(max-width: 440px) 108px, 120px"
           className="object-cover"
         />
+        <div className="absolute inset-0 bg-[linear-gradient(180deg,rgba(0,0,0,0.3)_0%,rgba(0,0,0,0)_100%)]" />
+        {thumbnailBadge && (
+          <div className="absolute top-2 left-2">{thumbnailBadge}</div>
+        )}
       </div>
       <div className="flex min-w-0 flex-1 flex-col gap-2">
         <div className="relative">

--- a/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
+++ b/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
@@ -312,39 +312,30 @@ export default function FeedDetailCard({ postId }: { postId: string }) {
             )}
           </div>
           <div className="flex flex-col gap-2.5 px-6 pt-3">
-            {!isMyPost && (
-              <div className="flex justify-between">
-                <div className="flex items-center gap-1.5">
-                  <LikeButton postId={post.postId} isLiked={post.like} />
-                  <span className="caption-md text-semantic-object-normal">
-                    {post.likes < 1000 ? post.likes : '999+'}
-                  </span>
-                </div>
-                <div className="flex items-center gap-3">
-                  <BookmarkButton
-                    postId={post.postId}
-                    isBookmarked={post.bookMark}
-                  />
-                  <ShareButton
-                    postId={post.postId}
-                    title={post.title}
-                    text={post.contents}
-                  />
-                </div>
+            <div className="flex justify-between">
+              <div className="flex items-center gap-1.5">
+                <LikeButton postId={post.postId} isLiked={post.like} />
+                <span className="caption-md text-semantic-object-normal">
+                  {post.likes < 1000 ? post.likes : '999+'}
+                </span>
               </div>
-            )}
+              <div className="flex items-center gap-3">
+                <BookmarkButton
+                  postId={post.postId}
+                  isBookmarked={post.bookMark}
+                />
+                <ShareButton
+                  postId={post.postId}
+                  title={post.title}
+                  text={post.contents}
+                />
+              </div>
+            </div>
             <div className="flex flex-col gap-1.5">
               <div className="flex items-center justify-between">
                 <Badge variant="soft" color="orange">
                   {post.category}
                 </Badge>
-                {isMyPost && (
-                  <ShareButton
-                    postId={post.postId}
-                    title={post.title}
-                    text={post.contents}
-                  />
-                )}
               </div>
               <div className="flex flex-col gap-1">
                 <span className="title-xs text-semantic-object-boldest">

--- a/apps/web/src/views/my/ui/BookmarkTab.tsx
+++ b/apps/web/src/views/my/ui/BookmarkTab.tsx
@@ -86,7 +86,7 @@ export default function BookmarkTab() {
       renderAction={(feed, viewType) => (
         <BookmarkButton
           className={
-            viewType === 'grid' ? 'text-semantic-object-subtle' : undefined
+            viewType === 'grid' ? 'text-semantic-object-subtler' : undefined
           }
           postId={feed.postId}
           isBookmarked={feed.bookMark}

--- a/apps/web/src/views/my/ui/RecordTab.tsx
+++ b/apps/web/src/views/my/ui/RecordTab.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { Icon, Spinner } from '@plog/ui';
+import { cn } from '@plog/utils';
 
 import { FeedList, type RecordTypeValue } from '@/widgets/feed-list';
 
@@ -84,14 +85,24 @@ export default function RecordTab() {
           />
         </div>
       }
-      renderAction={(feed) =>
-        !feed.isPublic && (
+      renderAction={(feed, viewType) => (
+        <BookmarkButton
+          className={
+            viewType === 'grid' ? 'text-semantic-object-subtler' : undefined
+          }
+          postId={feed.postId}
+          isBookmarked={feed.bookMark}
+        />
+      )}
+      renderThumbnailBadge={(feed) =>
+        !feed.isPublic ? (
           <Icon
             name="lock-filled"
-            className="text-semantic-object-subtle"
+            size={20}
+            className="text-semantic-object-subtler"
             aria-label="비공개 게시물"
           />
-        )
+        ) : undefined
       }
     />
   );

--- a/apps/web/src/views/my/ui/RecordTab.tsx
+++ b/apps/web/src/views/my/ui/RecordTab.tsx
@@ -5,7 +5,6 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { Icon, Spinner } from '@plog/ui';
-import { cn } from '@plog/utils';
 
 import { FeedList, type RecordTypeValue } from '@/widgets/feed-list';
 

--- a/apps/web/src/widgets/feed-list/ui/FeedList.tsx
+++ b/apps/web/src/widgets/feed-list/ui/FeedList.tsx
@@ -30,6 +30,7 @@ type FeedListProps = {
   tags?: PlaceTagValue[];
   onTagsChange?: (tags: PlaceTagValue[]) => void;
   renderAction?: (feed: FeedPost, viewType: FeedViewType) => ReactNode;
+  renderThumbnailBadge?: (feed: FeedPost) => ReactNode;
   onFeedClick?: (feed: FeedPost) => void;
   toolbarConfig?: ToolbarConfig;
   emptyView?: ReactNode;
@@ -44,6 +45,7 @@ export default function FeedList({
   tags = [],
   onTagsChange,
   renderAction,
+  renderThumbnailBadge,
   onFeedClick,
   toolbarConfig,
   emptyView,
@@ -128,6 +130,7 @@ export default function FeedList({
               feed={feed}
               onClick={onFeedClick ? () => onFeedClick(feed) : undefined}
               action={renderAction?.(feed, viewType)}
+              thumbnailBadge={renderThumbnailBadge?.(feed)}
             />
           ))}
         </div>


### PR DESCRIPTION
## 📌 관련 이슈

- closes #166

## 📝 작업 내용

- [x] 피드 상세 페이지 본인 게시글 좋아요/북마크/공유 버튼 항상 표시
- [x] 마이페이지 기록 탭 자물쇠 아이콘 → 북마크 버튼 교체
- [x] 비공개 게시물 자물쇠 아이콘을 리스트뷰 썸네일 좌상단으로 이동
- [x] 리스트뷰 썸네일 그라데이션 오버레이 추가 및 투명도 수정

## 🔎 자세한 설명

### ✅ 피드 상세 페이지 액션 버튼 노출 정책 수정

기존 `isMyPost` prop에 따라 액션 버튼 전체를 조건부로 렌더링하고 있어, 본인 게시글에서는 좋아요/북마크 버튼이 모두 숨겨지고 있었습니다. 정책상 본인 게시글도 북마크 및 좋아요 가능해야 하므로 해당 조건을 제거하고, 액션 버튼을 항상 표시하도록 변경했습니다.

### ✅ 마이페이지 기록 탭 자물쇠 아이콘 위치 변경

기존에는 `renderAction`에서 비공개 게시물일 때만 자물쇠 아이콘을 렌더링하고 있었습니다. 이를 수정해 북마크 버튼은 항상 표시하도록 변경했고, 비공개 여부는 리스트뷰 썸네일 좌상단의 자물쇠 아이콘으로 분리했습니다.

### ✅ `FeedListItem` `thumbnailBadge` prop 추가

`FeedGridItem`의 오버레이 영역처럼 `FeedListItem`에서도 썸네일 내부의 고정 위치에 아이콘 등을 렌더링할 수 있도록 `thumbnailBadge?: ReactNode` prop을 추가했습니다.

## 🖼️ 스크린샷
#### before
<img width="373" height="263" alt="image" src="https://github.com/user-attachments/assets/554a359d-dba9-4d9c-8486-dc75eb12b1ce" />

#### after
<img width="373" height="263" alt="image" src="https://github.com/user-attachments/assets/3e07f35a-c456-40e2-85b5-6cac16195463" />

## 💬 리뷰어에게

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
