### PR TITLE
fix: 커서 페이징 API 스펙 변경 반영 및 공통 헬퍼 추출

### DIFF
--- a/apps/web/src/shared/api/response.utils.ts
+++ b/apps/web/src/shared/api/response.utils.ts
@@ -26,5 +26,5 @@ export async function parseApiResponse<T>(res: Response): Promise<T> {
 export function getNextCursorPageParam(
   lastPage: CursorPage<unknown>,
 ): string | undefined {
-  return lastPage.hasNext ? lastPage.nextCursor : undefined;
+  return lastPage.hasNext ? (lastPage.nextCursor ?? undefined) : undefined;
 }

--- a/apps/web/src/shared/api/response.utils.ts
+++ b/apps/web/src/shared/api/response.utils.ts
@@ -1,4 +1,4 @@
-import { type ApiErrorCode, type ApiResponse } from './types';
+import { type ApiErrorCode, type ApiResponse, type CursorPage } from './types';
 
 export class ApiResponseError extends Error {
   constructor(
@@ -21,4 +21,10 @@ export async function parseApiResponse<T>(res: Response): Promise<T> {
     );
   }
   return json.data as T;
+}
+
+export function getNextCursorPageParam(
+  lastPage: CursorPage<unknown>,
+): string | undefined {
+  return lastPage.hasNext ? lastPage.nextCursor : undefined;
 }

--- a/apps/web/src/shared/api/types.ts
+++ b/apps/web/src/shared/api/types.ts
@@ -17,5 +17,5 @@ export type ApiErrorCode = (typeof API_ERROR_CODE)[keyof typeof API_ERROR_CODE];
 export type CursorPage<T> = {
   content: T[];
   hasNext: boolean;
-  nextCursor: string;
+  nextCursor: string | null;
 };

--- a/apps/web/src/shared/api/types.ts
+++ b/apps/web/src/shared/api/types.ts
@@ -17,4 +17,5 @@ export type ApiErrorCode = (typeof API_ERROR_CODE)[keyof typeof API_ERROR_CODE];
 export type CursorPage<T> = {
   content: T[];
   hasNext: boolean;
+  nextCursor: string;
 };

--- a/apps/web/src/views/map-place-feed/model/use-place-feed-query.ts
+++ b/apps/web/src/views/map-place-feed/model/use-place-feed-query.ts
@@ -10,6 +10,7 @@ import {
 } from '@/entities/place';
 
 import { clientApi } from '@/shared/api/client-api';
+import { getNextCursorPageParam } from '@/shared/api/response.utils';
 import { type CursorPage } from '@/shared/api/types';
 
 type PlacePost = {
@@ -48,17 +49,6 @@ function fetchPlacePosts(
   );
 }
 
-function buildCursor(sortType: MapSortType, last: PlacePost): string {
-  switch (sortType) {
-    case 'STUDY_TIME':
-      return `${last.studyTime}:${last.postId}`;
-    case 'FOCUS':
-      return `${last.focus}:${last.postId}`;
-    default:
-      return String(last.postId);
-  }
-}
-
 export function usePlaceFeedQuery(
   placeId: number,
   layer: PlaceLayer,
@@ -75,10 +65,6 @@ export function usePlaceFeedQuery(
         limit: LIMIT,
       }),
     initialPageParam: '',
-    getNextPageParam: (lastPage) => {
-      if (!lastPage.hasNext) return undefined;
-      const last = lastPage.content[lastPage.content.length - 1];
-      return last ? buildCursor(sortType, last) : undefined;
-    },
+    getNextPageParam: getNextCursorPageParam,
   });
 }

--- a/apps/web/src/views/map/model/use-map-sheet-query.ts
+++ b/apps/web/src/views/map/model/use-map-sheet-query.ts
@@ -9,6 +9,7 @@ import {
 } from '@/entities/place';
 
 import { clientApi } from '@/shared/api/client-api';
+import { getNextCursorPageParam } from '@/shared/api/response.utils';
 import { type CursorPage } from '@/shared/api/types';
 
 import { type MapSheetPlace } from './types';
@@ -30,27 +31,12 @@ function fetchMapSheetPlaces(
   );
 }
 
-function buildCursor(sortType: MapSortType, last: MapSheetPlace): string {
-  switch (sortType) {
-    case 'LATEST':
-      return `${last.lastStudyDate}:${last.placeId}`;
-    case 'RECORD_COUNT':
-      return `${last.count}:${last.placeId}`;
-    default:
-      return String(last.placeId);
-  }
-}
-
 export function useMapSheetQuery(layer: PlaceLayer, sortType: MapSortType) {
   return useInfiniteQuery({
     queryKey: mapQueryKeys.sheet(layer, sortType),
     queryFn: ({ pageParam }) =>
       fetchMapSheetPlaces(layer, { sortType, cursor: pageParam, limit: LIMIT }),
     initialPageParam: '',
-    getNextPageParam: (lastPage) => {
-      if (!lastPage.hasNext) return undefined;
-      const last = lastPage.content[lastPage.content.length - 1];
-      return last ? buildCursor(sortType, last) : undefined;
-    },
+    getNextPageParam: getNextCursorPageParam,
   });
 }


### PR DESCRIPTION
## 📌 관련 이슈

- closes #168 

## 📝 작업 내용

- [x] `CursorPage<T>` 타입에 `nextCursor: string | null` 필드 추가
- [x] `getNextCursorPageParam` 공통 헬퍼 추가
- [x] 각 커서 페이징 쿼리 훅에서 `buildCursor` 제거 및 헬퍼 적용

## 🔎 자세한 설명

API 스펙 변경으로 커서 페이징 응답에 `nextCursor` 필드가 추가되었습니다.

기존에는 클라이언트에서 `sortType`에 따라 마지막 아이템 값을 조합해 커서를 직접 생성하고 있었습니다.

```ts
// before
function buildCursor(sortType: MapSortType, last: MapSheetPlace): string {
  switch (sortType) {
    case 'LATEST': return `${last.lastStudyDate}:${last.placeId}`;
    case 'RECORD_COUNT': return `${last.count}:${last.placeId}`;
    default: return String(last.placeId);
  }
}
```

이제 서버가 `nextCursor`를 직접 내려주도록 변경되면서 `buildCursor`가 불필요해졌고, `getNextPageParam`의 공통 로직을 `shared/api/response.utils.ts`의 헬퍼로 분리했습니다.

```ts
// after
export function getNextCursorPageParam(lastPage: CursorPage<unknown>): string | undefined {
  return lastPage.hasNext ? (lastPage.nextCursor ?? undefined) : undefined;
}
```

이후 동일한 `CursorPage` 구조를 사용하는 커서 기반 API가 추가되면 재사용할 수 있습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
