### PR TITLE
fix: useScrollLock을 position fixed 방식으로 수정

### DIFF
--- a/apps/web/src/shared/lib/scroll-lock/use-scroll-lock.ts
+++ b/apps/web/src/shared/lib/scroll-lock/use-scroll-lock.ts
@@ -1,15 +1,21 @@
 import { useEffect } from 'react';
 
+let savedScrollY = 0;
+
 function lockBodyScroll() {
-  document.body.style.overflow = 'hidden';
-  document.documentElement.style.overflow = 'hidden';
+  savedScrollY = window.scrollY;
+  document.body.style.position = 'fixed';
+  document.body.style.top = `-${savedScrollY}px`;
+  document.body.style.width = '100%';
   document.body.style.touchAction = 'none';
 }
 
 function unlockBodyScroll() {
-  document.body.style.overflow = '';
-  document.documentElement.style.overflow = '';
+  document.body.style.position = '';
+  document.body.style.top = '';
+  document.body.style.width = '';
   document.body.style.touchAction = '';
+  window.scrollTo(0, savedScrollY);
 }
 
 export function useScrollLock() {


### PR DESCRIPTION
## 📌 관련 이슈

- closes #172 

## 📝 작업 내용

- [x] `useScrollLock`을 `overflow: hidden`에서 `position: fixed` 방식으로 수정

## 🔎 자세한 설명

`globals.css`에서 `html`, `body`에 `scrollbar-gutter: stable`이 적용되어 있어 스크롤바 영역이 항상 예약됩니다.

기존 `useScrollLock`은 `overflow: hidden`으로 스크롤을 막았는데, 이때 scrollbar gutter 영역도 함께 사라져 장소 검색 오버레이 오픈 시 레이아웃 시프트가 발생했습니다.

이를 해결하기 위해 `overflow` 대신 `body`를 `position: fixed`로 고정하는 방식으로 변경했고, 해제 시 `window.scrollTo`로 기존 스크롤 위치를 복원하도록 수정했습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

@coderabbitai ignore

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
