### PR TITLE
feat: 지도 페이지에서 기록 추가 시 장소 자동 입력

### DIFF
--- a/apps/web/src/features/create-log/model/types.ts
+++ b/apps/web/src/features/create-log/model/types.ts
@@ -6,7 +6,6 @@ import { type PlaceCategoryValue } from '@/entities/place';
 export type FocusLevel = 1 | 2 | 3 | 4 | 5;
 
 export type CreateLogPlace = {
-  id: string;
   name: string;
   address: string;
   latitude: number;

--- a/apps/web/src/features/place-search/model/selected-place.ts
+++ b/apps/web/src/features/place-search/model/selected-place.ts
@@ -1,5 +1,4 @@
 export type SelectedPlace = {
-  id: string;
   name: string;
   address: string;
   latitude: number;
@@ -14,7 +13,6 @@ export function createSelectedPlace(
   place: kakao.maps.services.PlacesSearchResultItem,
 ): SelectedPlace {
   return {
-    id: place.id,
     name: place.place_name,
     address: getDisplayAddress(place),
     latitude: Number(place.y),

--- a/apps/web/src/views/log/model/mapper.ts
+++ b/apps/web/src/views/log/model/mapper.ts
@@ -44,7 +44,6 @@ function existingPhoto(image: PostImage): ExistingPhotoPreview {
 
 function postEditPlace(post: EditData['post']) {
   return {
-    id: `edit-${post.place.latitude}-${post.place.longitude}-${post.place.name}`,
     name: post.place.name,
     address: post.place.address,
     latitude: post.place.latitude,

--- a/apps/web/src/views/log/model/schema.ts
+++ b/apps/web/src/views/log/model/schema.ts
@@ -28,7 +28,6 @@ const dateSchema = z.object({
 });
 
 const placeSchema = z.object({
-  id: z.string().min(1),
   name: z.string().trim().min(1, '작업 장소를 선택해 주세요.'),
   address: z.string().trim().min(1, '장소 주소를 확인해 주세요.'),
   latitude: z.number(),

--- a/apps/web/src/views/log/model/use-create-log-page.ts
+++ b/apps/web/src/views/log/model/use-create-log-page.ts
@@ -13,7 +13,23 @@ import { useRouter } from 'next/navigation';
 
 import { useToast } from '@plog/ui';
 
-import { initialCreateLogValues } from '@/features/create-log';
+import {
+  type CreateLogPlace,
+  initialCreateLogValues,
+} from '@/features/create-log';
+
+const MAP_INITIAL_PLACE_KEY = 'map:initial-place';
+
+function readMapInitialPlace(): CreateLogPlace | null {
+  try {
+    const saved = sessionStorage.getItem(MAP_INITIAL_PLACE_KEY);
+    if (!saved) return null;
+    sessionStorage.removeItem(MAP_INITIAL_PLACE_KEY);
+    return JSON.parse(saved) as CreateLogPlace;
+  } catch {
+    return null;
+  }
+}
 
 import { dialog } from '@/shared/lib/dialog';
 import { IMAGE_UPLOAD_MAX_FILE_SIZE } from '@/shared/lib/image-upload-policy';
@@ -65,6 +81,7 @@ export function useCreateLogPage(editPostId?: string) {
     defaultValues: {
       ...initialCreateLogValues,
       photos: [],
+      place: !isEditMode ? readMapInitialPlace() : null,
     },
     mode: 'onChange',
     reValidateMode: 'onChange',

--- a/apps/web/src/views/log/model/use-create-log-page.ts
+++ b/apps/web/src/views/log/model/use-create-log-page.ts
@@ -21,11 +21,23 @@ import {
 const MAP_INITIAL_PLACE_KEY = 'map:initial-place';
 
 function readMapInitialPlace(): CreateLogPlace | null {
+  if (typeof window === 'undefined') return null;
   try {
     const saved = sessionStorage.getItem(MAP_INITIAL_PLACE_KEY);
     if (!saved) return null;
+    const parsed: unknown = JSON.parse(saved);
+    if (
+      typeof parsed !== 'object' ||
+      parsed === null ||
+      typeof (parsed as Record<string, unknown>).name !== 'string' ||
+      typeof (parsed as Record<string, unknown>).address !== 'string' ||
+      typeof (parsed as Record<string, unknown>).latitude !== 'number' ||
+      typeof (parsed as Record<string, unknown>).longitude !== 'number'
+    ) {
+      return null;
+    }
     sessionStorage.removeItem(MAP_INITIAL_PLACE_KEY);
-    return JSON.parse(saved) as CreateLogPlace;
+    return parsed as CreateLogPlace;
   } catch {
     return null;
   }

--- a/apps/web/src/views/log/ui/PlaceSearchOverlay.tsx
+++ b/apps/web/src/views/log/ui/PlaceSearchOverlay.tsx
@@ -123,7 +123,6 @@ export default function PlaceSearchOverlay({
 
   const handleSelectRecentPlace = (place: RecentPlace) =>
     saveAndSelect({
-      id: String(place.id),
       name: place.placeName,
       address: place.address,
       latitude: place.latitude,

--- a/apps/web/src/views/map/ui/MapPage.tsx
+++ b/apps/web/src/views/map/ui/MapPage.tsx
@@ -61,6 +61,12 @@ export default function MapPage() {
   const [fromList, setFromList] = useState(false);
   const [recordVisible, setRecordVisible] = useState(true);
   const [bookmarkVisible, setBookmarkVisible] = useState(true);
+  const [selectedCoords, setSelectedCoords] = useState<{
+    lat: number;
+    lng: number;
+  } | null>(
+    initSelection ? { lat: initSelection.lat, lng: initSelection.lng } : null,
+  );
 
   const handle = useMemo(() => BottomSheet.createHandle(), []);
   const listHandle = useMemo(() => BottomSheet.createHandle(), []);
@@ -91,10 +97,12 @@ export default function MapPage() {
     onPlaceSelect: (pin, type) => {
       if (!pin || !type) {
         setSelectedPlaceId(null);
+        setSelectedCoords(null);
         return;
       }
       setSelectedPlaceId(pin.placeId);
       setSelectedType(type);
+      setSelectedCoords({ lat: pin.latitude, lng: pin.longitude });
       setFromList(false);
       handle.close();
       listHandle.close();
@@ -147,6 +155,7 @@ export default function MapPage() {
   ) => {
     setSelectedPlaceId(placeId);
     setSelectedType(type);
+    setSelectedCoords({ lat: latitude, lng: longitude });
     setFromList(true);
     pendingRef.current = { placeId, type, lat: latitude, lng: longitude };
     selectPin(placeId, type);
@@ -157,12 +166,14 @@ export default function MapPage() {
     pendingRef.current = null;
     deselect();
     setSelectedPlaceId(null);
+    setSelectedCoords(null);
     setFromList(false);
   };
 
   const handleSelectedBack = () => {
     pendingRef.current = null;
     setSelectedPlaceId(null);
+    setSelectedCoords(null);
     setFromList(false);
     listHandle.open(null);
   };
@@ -175,6 +186,17 @@ export default function MapPage() {
   };
 
   const handleCreatePost = () => {
+    if (selectedPlace && selectedCoords) {
+      sessionStorage.setItem(
+        'map:initial-place',
+        JSON.stringify({
+          name: selectedPlace.placeName,
+          address: selectedPlace.address,
+          latitude: selectedCoords.lat,
+          longitude: selectedCoords.lng,
+        }),
+      );
+    }
     router.push('/log');
   };
 


### PR DESCRIPTION
## 📌 관련 이슈

- closes #176 

## 📝 작업 내용

- [x] `MapPage`에 `selectedCoords` state 추가 및 핀 선택 좌표 보관
- [x] `handleCreatePost`에서 장소 정보를 세션 스토리지에 저장 후 `/log`로 이동
- [x] `useCreateLogPage`에서 마운트 시 세션 스토리지 값을 읽어 폼 `defaultValues`에 반영
- [x] `CreateLogPlace`, `SelectedPlace`, `placeSchema`의 미사용 `id` 필드 제거

## 🔎 자세한 설명

처음에는 장소 정보를 쿼리 파라미터로 전달하는 방식으로 구현하려고 했지만, URL이 길어지고 URL 수정만으로 임의의 장소 정보를 주입할 수 있어 세션 스토리지 기반으로 구현했습니다. 값은 읽은 직후 삭제하여 일회성 데이터로만 사용합니다.

또한 `MapPinDetail`에 좌표 정보가 없어, 핀 선택 시점(`onPlaceSelect`, `handlePlaceSelect`)에 전달받은 좌표를 `selectedCoords` state로 관리하도록 수정했습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

현재는 클라이언트에서만 장소 정보를 관리하고 있고, 서버 단 좌표/장소 검증은 없는 것으로 보여 완전한 우회 방지는 어려운 상태입니다. 서버 단 검증이 필요한지는 논의가 필요할 것 같습니다!

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
