### PR TITLE
fix: 약관 페이지 본문 텍스트 간격 수정

### DIFF
--- a/apps/web/src/views/terms/ui/TermsPage.tsx
+++ b/apps/web/src/views/terms/ui/TermsPage.tsx
@@ -27,7 +27,7 @@ export default function TermsPage({ title, content }: TermsPageProps) {
         dangerouslySetInnerHTML={{ __html: content }}
         className={cn(
           'body-sm min-h-dvh p-6 pt-[calc(24px+var(--spacing-header))] text-semantic-object-bold',
-          '[&_h2]:-mb-1 [&_h2]:text-semantic-title-md [&_h2]:leading-semantic-title-md [&_h2]:font-semantic-title-md',
+          '[&_h2]:-mb-1 [&_h2]:text-semantic-title-md [&_h2]:leading-semantic-title-md [&_h2]:font-semantic-title-md [&_h2+p]:pt-4 [&_p+p]:mt-2',
           '[&_h4]:pt-7 [&_h4]:pb-3 [&_h4]:text-semantic-label-lg [&_h4]:leading-semantic-label-lg [&_h4]:font-semantic-label-lg',
           '[&_ol]:list-decimal [&_ol]:pl-4 [&_ol_ol]:list-[lower-alpha]',
           '[&_hr]:-mx-6 [&_hr]:my-6 [&_hr]:border-4 [&_hr]:border-semantic-bg-deep',


### PR DESCRIPTION
## 📌 관련 이슈

- closes #182 

## 📝 작업 내용

- [x] `h2` 바로 다음 `p`에 상단 여백 추가
- [x] 연속된 `p` 태그 사이 간격 추가

## 🔎 자세한 설명

## 🖼️ 스크린샷

#### before
<img width="325" height="331" alt="image" src="https://github.com/user-attachments/assets/e84a40db-8827-43fd-8792-89c807fa6e8f" />

#### after
<img width="325" height="331" alt="image" src="https://github.com/user-attachments/assets/16278d42-f788-427f-96bd-a53a6a2db7f3" />

## 💬 리뷰어에게

@coderabbitai ignore

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
