### PR TITLE
chore: Amplitude Analytics 사용자 행동 분석 환경 설정

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,6 +12,7 @@
     "clean": "rm -rf .next"
   },
   "dependencies": {
+    "@amplitude/unified": "^1.1.11",
     "@lottiefiles/dotlottie-react": "^0.19.4",
     "@plog/ui": "workspace:*",
     "@plog/utils": "workspace:^",

--- a/apps/web/src/features/share-post/ui/ShareButton.tsx
+++ b/apps/web/src/features/share-post/ui/ShareButton.tsx
@@ -1,14 +1,21 @@
 'use client';
 
+import * as amplitude from '@amplitude/unified';
 import { Icon, useToast } from '@plog/ui';
 
 type ShareButtonProps = {
   postId: number;
   title?: string;
   text?: string;
+  isOwner?: boolean;
 };
 
-export default function ShareButton({ postId, title, text }: ShareButtonProps) {
+export default function ShareButton({
+  postId,
+  title,
+  text,
+  isOwner,
+}: ShareButtonProps) {
   const { toast } = useToast();
 
   const url = `${window.location.origin}/feed/${postId}`;
@@ -36,6 +43,10 @@ export default function ShareButton({ postId, title, text }: ShareButtonProps) {
   };
 
   const handleShare = async () => {
+    amplitude.track('share_clicked', {
+      post_id: postId,
+      is_owner: isOwner ?? false,
+    });
     if (!navigator.share) {
       await handleCopy();
       return;

--- a/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
+++ b/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import * as amplitude from '@amplitude/unified';
 import { useToast } from '@plog/ui';
 import {
   type InfiniteData,
@@ -92,6 +93,7 @@ export type ProfilePostsBookmarkTarget = {
 type ToggleBookmarkVariables = {
   postId: number;
   profilePostsTarget?: ProfilePostsBookmarkTarget;
+  disableTracking?: boolean;
 };
 
 export function useToggleBookmark() {
@@ -157,20 +159,26 @@ export function useToggleBookmark() {
         description: '북마크 처리 중 오류가 발생했어요.',
       });
     },
-    onSuccess: (res, { postId }, context) => {
+    onSuccess: (data, { postId, disableTracking }, context) => {
+      if (!disableTracking) {
+        amplitude.track('bookmark_toggled', {
+          post_id: postId,
+          bookmarked: data.isBookmarked,
+        });
+      }
       queryClient.setQueryData<InfiniteData<FeedPage>>(
         feedQueryKeys.list,
-        (prev) => updateBookmarkInFeedCache(prev, postId, res.isBookmarked),
+        (prev) => updateBookmarkInFeedCache(prev, postId, data.isBookmarked),
       );
       queryClient.setQueryData<FeedPost>(
         feedQueryKeys.detail(postId),
-        (prev) => (prev ? { ...prev, bookMark: res.isBookmarked } : prev),
+        (prev) => (prev ? { ...prev, bookMark: data.isBookmarked } : prev),
       );
       if (context.profilePostsQueryKey) {
         queryClient.setQueryData<FeedProfilePosts>(
           context.profilePostsQueryKey,
           (prev) =>
-            updateBookmarkInProfilePostsCache(prev, postId, res.isBookmarked),
+            updateBookmarkInProfilePostsCache(prev, postId, data.isBookmarked),
         );
       }
       queryClient.invalidateQueries({ queryKey: mypageQueryKeys.all });
@@ -193,6 +201,7 @@ export function useToggleBookmark() {
     postId: number,
     isBookmarked: boolean,
     profilePostsTarget?: ProfilePostsBookmarkTarget,
+    disableTracking?: boolean,
   ): Promise<boolean> => {
     if (isBookmarked) {
       const confirmed = await dialog.confirm({
@@ -203,7 +212,7 @@ export function useToggleBookmark() {
       if (!confirmed) return false;
     }
 
-    mutation.mutate({ postId, profilePostsTarget });
+    mutation.mutate({ postId, profilePostsTarget, disableTracking });
     return true;
   };
 

--- a/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
+++ b/apps/web/src/features/toggle-bookmark/model/use-toggle-bookmark.ts
@@ -183,7 +183,9 @@ export function useToggleBookmark() {
       });
       queryClient.invalidateQueries({ queryKey: mapQueryKeys.pinDetailAll() });
       queryClient.invalidateQueries({ queryKey: mapQueryKeys.placeAll() });
-      queryClient.invalidateQueries({ queryKey: feedQueryKeys.profileViewAll() });
+      queryClient.invalidateQueries({
+        queryKey: feedQueryKeys.profileViewAll(),
+      });
     },
   });
 

--- a/apps/web/src/features/toggle-bookmark/ui/BookmarkButton.tsx
+++ b/apps/web/src/features/toggle-bookmark/ui/BookmarkButton.tsx
@@ -2,7 +2,6 @@
 
 import { type MouseEvent, useEffect, useState } from 'react';
 
-import * as amplitude from '@amplitude/unified';
 import { Icon } from '@plog/ui';
 import { cn } from '@plog/utils';
 
@@ -41,14 +40,9 @@ export default function BookmarkButton({
       postId,
       optimisticBookmarked,
       profilePostsTarget,
+      disableTracking,
     );
     if (proceeded) {
-      if (!disableTracking) {
-        amplitude.track('bookmark_toggled', {
-          post_id: postId,
-          bookmarked: !optimisticBookmarked,
-        });
-      }
       setOptimisticBookmarked((prev) => !prev);
     }
   };

--- a/apps/web/src/features/toggle-bookmark/ui/BookmarkButton.tsx
+++ b/apps/web/src/features/toggle-bookmark/ui/BookmarkButton.tsx
@@ -2,6 +2,7 @@
 
 import { type MouseEvent, useEffect, useState } from 'react';
 
+import * as amplitude from '@amplitude/unified';
 import { Icon } from '@plog/ui';
 import { cn } from '@plog/utils';
 
@@ -13,6 +14,7 @@ import {
 type BookmarkButtonProps = {
   postId: number;
   isBookmarked: boolean;
+  disableTracking?: boolean;
   profilePostsTarget?: ProfilePostsBookmarkTarget;
   className?: string;
 };
@@ -20,6 +22,7 @@ type BookmarkButtonProps = {
 export default function BookmarkButton({
   postId,
   isBookmarked,
+  disableTracking,
   profilePostsTarget,
   className,
 }: BookmarkButtonProps) {
@@ -39,7 +42,15 @@ export default function BookmarkButton({
       optimisticBookmarked,
       profilePostsTarget,
     );
-    if (proceeded) setOptimisticBookmarked((prev) => !prev);
+    if (proceeded) {
+      if (!disableTracking) {
+        amplitude.track('bookmark_toggled', {
+          post_id: postId,
+          bookmarked: !optimisticBookmarked,
+        });
+      }
+      setOptimisticBookmarked((prev) => !prev);
+    }
   };
 
   return (

--- a/apps/web/src/features/toggle-like/model/use-toggle-like.ts
+++ b/apps/web/src/features/toggle-like/model/use-toggle-like.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import * as amplitude from '@amplitude/unified';
 import { useToast } from '@plog/ui';
 import {
   type InfiniteData,
@@ -41,7 +42,8 @@ export function useToggleLike() {
   const { toast } = useToast();
 
   const mutation = useMutation({
-    mutationFn: ({ postId }: { postId: number }) => postToggleLike(postId),
+    mutationFn: ({ postId }: { postId: number; disableTracking?: boolean }) =>
+      postToggleLike(postId),
     onMutate: async ({ postId }) => {
       await queryClient.cancelQueries({
         queryKey: feedQueryKeys.list,
@@ -61,6 +63,14 @@ export function useToggleLike() {
         (prev) => (prev ? applyLike(prev, !prev.like) : prev),
       );
     },
+    onSuccess: (data, { postId, disableTracking }) => {
+      if (!disableTracking) {
+        amplitude.track('like_toggled', {
+          post_id: postId,
+          liked: data.isLiked,
+        });
+      }
+    },
     onError: () => {
       toast({
         id: 'like-error',
@@ -79,8 +89,8 @@ export function useToggleLike() {
     },
   });
 
-  const toggleLike = (postId: number) => {
-    mutation.mutate({ postId });
+  const toggleLike = (postId: number, disableTracking?: boolean) => {
+    mutation.mutate({ postId, disableTracking });
   };
 
   return { toggleLike, isPending: mutation.isPending };

--- a/apps/web/src/features/toggle-like/ui/LikeButton.tsx
+++ b/apps/web/src/features/toggle-like/ui/LikeButton.tsx
@@ -2,6 +2,7 @@
 
 import { type MouseEvent, useEffect, useState } from 'react';
 
+import * as amplitude from '@amplitude/unified';
 import { Icon } from '@plog/ui';
 import { cn } from '@plog/utils';
 
@@ -10,12 +11,14 @@ import { useToggleLike } from '../model/use-toggle-like';
 type LikeButtonProps = {
   postId: number;
   isLiked: boolean;
+  disableTracking?: boolean;
   className?: string;
 };
 
 export default function LikeButton({
   postId,
   isLiked,
+  disableTracking,
   className,
 }: LikeButtonProps) {
   const [optimisticLiked, setOptimisticLiked] = useState(isLiked);
@@ -28,6 +31,12 @@ export default function LikeButton({
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
+    if (!disableTracking) {
+      amplitude.track('like_toggled', {
+        post_id: postId,
+        liked: !optimisticLiked,
+      });
+    }
     setOptimisticLiked((prev) => !prev);
     toggleLike(postId);
   };

--- a/apps/web/src/features/toggle-like/ui/LikeButton.tsx
+++ b/apps/web/src/features/toggle-like/ui/LikeButton.tsx
@@ -2,7 +2,6 @@
 
 import { type MouseEvent, useEffect, useState } from 'react';
 
-import * as amplitude from '@amplitude/unified';
 import { Icon } from '@plog/ui';
 import { cn } from '@plog/utils';
 
@@ -31,14 +30,8 @@ export default function LikeButton({
 
   const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
     event.stopPropagation();
-    if (!disableTracking) {
-      amplitude.track('like_toggled', {
-        post_id: postId,
-        liked: !optimisticLiked,
-      });
-    }
     setOptimisticLiked((prev) => !prev);
-    toggleLike(postId);
+    toggleLike(postId, disableTracking);
   };
 
   return (

--- a/apps/web/src/shared/ui/Providers.tsx
+++ b/apps/web/src/shared/ui/Providers.tsx
@@ -2,11 +2,17 @@
 
 import { type ReactNode, useState } from 'react';
 
+import * as amplitude from '@amplitude/unified';
 import { ToastProvider } from '@plog/ui';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import GlobalDialog from './GlobalDialog';
+
+amplitude.initAll(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY!, {
+  analytics: { autocapture: true },
+  sessionReplay: { sampleRate: 1 },
+});
 
 export default function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(

--- a/apps/web/src/shared/ui/Providers.tsx
+++ b/apps/web/src/shared/ui/Providers.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { type ReactNode, useState } from 'react';
+import { type ReactNode, useEffect, useState } from 'react';
 
 import * as amplitude from '@amplitude/unified';
 import { ToastProvider } from '@plog/ui';
@@ -8,13 +8,6 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import GlobalDialog from './GlobalDialog';
-
-if (process.env.NODE_ENV === 'production') {
-  amplitude.initAll(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY!, {
-    analytics: { autocapture: true },
-    sessionReplay: { sampleRate: 0.1 },
-  });
-}
 
 export default function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(
@@ -28,6 +21,19 @@ export default function Providers({ children }: { children: ReactNode }) {
         },
       }),
   );
+
+  useEffect(() => {
+    if (
+      process.env.NODE_ENV !== 'production' ||
+      !process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY
+    )
+      return;
+
+    amplitude.initAll(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY, {
+      analytics: { autocapture: true },
+      sessionReplay: { sampleRate: 0.1 },
+    });
+  }, []);
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/apps/web/src/shared/ui/Providers.tsx
+++ b/apps/web/src/shared/ui/Providers.tsx
@@ -9,10 +9,12 @@ import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 
 import GlobalDialog from './GlobalDialog';
 
-amplitude.initAll(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY!, {
-  analytics: { autocapture: true },
-  sessionReplay: { sampleRate: 1 },
-});
+if (process.env.NODE_ENV === 'production') {
+  amplitude.initAll(process.env.NEXT_PUBLIC_AMPLITUDE_API_KEY!, {
+    analytics: { autocapture: true },
+    sessionReplay: { sampleRate: 0.1 },
+  });
+}
 
 export default function Providers({ children }: { children: ReactNode }) {
   const [queryClient] = useState(

--- a/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
+++ b/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
@@ -297,6 +297,7 @@ export default function FeedDetailCard({
                   postId={post.postId}
                   title={post.title}
                   text={post.contents}
+                  isOwner={isMyPost}
                 />
               </div>
             </div>

--- a/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
+++ b/apps/web/src/views/feed-detail/ui/FeedDetailCard.tsx
@@ -278,7 +278,11 @@ export default function FeedDetailCard({
           <div className="flex flex-col gap-2.5 px-6 pt-3">
             <div className="flex justify-between">
               <div className="flex items-center gap-1.5">
-                <LikeButton postId={post.postId} isLiked={post.like} />
+                <LikeButton
+                  postId={post.postId}
+                  isLiked={post.like}
+                  disableTracking={isMyPost}
+                />
                 <span className="caption-md text-semantic-object-normal">
                   {post.likes < 1000 ? post.likes : '999+'}
                 </span>
@@ -287,6 +291,7 @@ export default function FeedDetailCard({
                 <BookmarkButton
                   postId={post.postId}
                   isBookmarked={post.bookMark}
+                  disableTracking={isMyPost}
                 />
                 <ShareButton
                   postId={post.postId}

--- a/apps/web/src/views/feed/ui/FeedCard.tsx
+++ b/apps/web/src/views/feed/ui/FeedCard.tsx
@@ -214,6 +214,7 @@ export default function FeedCard({ post, isLast }: FeedCardProps) {
                 postId={post.postId}
                 title={post.title}
                 text={post.contents}
+                isOwner={post.isAuthor}
               />
             </div>
           </div>

--- a/apps/web/src/views/feed/ui/FeedCard.tsx
+++ b/apps/web/src/views/feed/ui/FeedCard.tsx
@@ -195,7 +195,11 @@ export default function FeedCard({ post, isLast }: FeedCardProps) {
         <div className="flex flex-col gap-2.5 px-6 pt-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-1.5">
-              <LikeButton postId={post.postId} isLiked={post.like} />
+              <LikeButton
+                postId={post.postId}
+                isLiked={post.like}
+                disableTracking={post.isAuthor}
+              />
               <span className="caption-md text-semantic-object-normal">
                 {post.likes < 1000 ? post.likes : '999+'}
               </span>
@@ -204,6 +208,7 @@ export default function FeedCard({ post, isLast }: FeedCardProps) {
               <BookmarkButton
                 postId={post.postId}
                 isBookmarked={post.bookMark}
+                disableTracking={post.isAuthor}
               />
               <ShareButton
                 postId={post.postId}

--- a/apps/web/src/views/log/model/use-create-log-mutation.ts
+++ b/apps/web/src/views/log/model/use-create-log-mutation.ts
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 
+import * as amplitude from '@amplitude/unified';
 import { useToast } from '@plog/ui';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -35,6 +36,7 @@ export function useCreateLogMutation({
     mutationFn: (values: CreateLogFormValues) =>
       createPost(createLogForm(values), getNewPhotoFiles(values)),
     onSuccess: async () => {
+      amplitude.track('log_created');
       onSuccess?.();
       await queryClient.invalidateQueries({ queryKey: feedQueryKeys.list });
       toast({ type: 'success', description: '기록이 등록되었어요.' });

--- a/apps/web/src/views/log/model/use-update-log-mutation.ts
+++ b/apps/web/src/views/log/model/use-update-log-mutation.ts
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 
+import * as amplitude from '@amplitude/unified';
 import { useToast } from '@plog/ui';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
@@ -50,6 +51,7 @@ export function useUpdateLogMutation({
       );
     },
     onSuccess: async () => {
+      amplitude.track('log_updated', { post_id: postId });
       onSuccess?.();
       await queryClient.invalidateQueries({ queryKey: feedQueryKeys.list });
       toast({ type: 'success', description: '기록이 수정되었어요.' });

--- a/apps/web/src/views/my/ui/BookmarkTab.tsx
+++ b/apps/web/src/views/my/ui/BookmarkTab.tsx
@@ -90,6 +90,7 @@ export default function BookmarkTab() {
           }
           postId={feed.postId}
           isBookmarked={feed.bookMark}
+          disableTracking
         />
       )}
     />

--- a/apps/web/src/views/my/ui/RecordTab.tsx
+++ b/apps/web/src/views/my/ui/RecordTab.tsx
@@ -91,6 +91,7 @@ export default function RecordTab() {
           }
           postId={feed.postId}
           isBookmarked={feed.bookMark}
+          disableTracking
         />
       )}
       renderThumbnailBadge={(feed) =>

--- a/apps/web/src/views/signup/ui/ProfileSetupStep.tsx
+++ b/apps/web/src/views/signup/ui/ProfileSetupStep.tsx
@@ -2,6 +2,7 @@
 
 import { useRouter } from 'next/navigation';
 
+import * as amplitude from '@amplitude/unified';
 import { AppBar, useToast } from '@plog/ui';
 import { useMutation } from '@tanstack/react-query';
 
@@ -34,6 +35,7 @@ export default function ProfileSetupStep({
         imageOption,
       ),
     onSuccess: () => {
+      amplitude.track('signup_completed');
       toast({ type: 'success', description: '회원가입이 완료되었어요.' });
       router.push('/');
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,9 @@ importers:
 
   apps/web:
     dependencies:
+      '@amplitude/unified':
+        specifier: ^1.1.11
+        version: 1.1.11(@amplitude/rrweb@2.1.1)(rollup@4.61.0)
       '@lottiefiles/dotlottie-react':
         specifier: ^0.19.4
         version: 0.19.4(react@19.2.4)
@@ -275,6 +278,107 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@amplitude/analytics-browser@2.42.5':
+    resolution: {integrity: sha512-+h3oBppdQWoeIL1f6Xrq0uUx+ffRX/FQBA6OILR2V3cet/qj9PA0t5qi8mrCGPN7Ef9Xjg7fVEVDHQ4ozWHkDg==}
+
+  '@amplitude/analytics-client-common@2.4.48':
+    resolution: {integrity: sha512-jdRvu8ux3aIf74FvTDZuSFR1mutzdrIg1ebXYqpKizs9upXz1AJnHClkldSw9i4yu924AJ2wudxq6dccHWlNiA==}
+
+  '@amplitude/analytics-connector@1.6.4':
+    resolution: {integrity: sha512-SpIv0IQMNIq6SH3UqFGiaZyGSc7PBZwRdq7lvP0pBxW8i4Ny+8zwI0pV+VMfMHQwWY3wdIbWw5WQphNjpdq1/Q==}
+
+  '@amplitude/analytics-core@2.48.2':
+    resolution: {integrity: sha512-r9O+hsTnTsDa1p6QdyC0KbBPXupzoWz9053RQB9XQz8078LM+5KCMbCKYOrSYniH4DH/OM2kOUEdJlwdxIl/IA==}
+
+  '@amplitude/analytics-types@1.4.0':
+    resolution: {integrity: sha512-RiMPHBqdrJ8ktTqG+Wzj2htnN/PCG9jGZG0SXtTFnWwVvcAJYbYm55/nrP1TTyrx1OlLhvF2VG3lVUP/xGAU8w==}
+
+  '@amplitude/analytics-types@2.11.1':
+    resolution: {integrity: sha512-wFEgb0t99ly2uJKm5oZ28Lti0Kh5RecR5XBkwfUpDzn84IoCIZ8GJTsMw/nThu8FZFc7xFDA4UAt76zhZKrs9A==}
+
+  '@amplitude/engagement-browser@1.0.10':
+    resolution: {integrity: sha512-sv8ei+Xy2qMs31lvW3bJCOZBg8LRuorAxlzM8fmh3FyVaRMbs5WyQGaWSfJ8y5tqmllJnLfbBS5R38Mv6G3h7w==}
+
+  '@amplitude/experiment-core@0.13.1':
+    resolution: {integrity: sha512-ZHvR0dxTltasp8MiMcQ6qKsY20mWnODoy3oebGad6qaRR1ywpUi8IuLf5AwLTM35ZwgzEUTn9TEIWKLHpDwHMw==}
+
+  '@amplitude/experiment-core@0.7.2':
+    resolution: {integrity: sha512-Wc2NWvgQ+bLJLeF0A9wBSPIaw0XuqqgkPKsoNFQrmS7r5Djd56um75In05tqmVntPJZRvGKU46pAp8o5tdf4mA==}
+
+  '@amplitude/experiment-js-client@1.21.1':
+    resolution: {integrity: sha512-chE/4qQG/5Cgl93Wqj1NEdgOL5LkqySLlfk1EN0f+7bJa52HpkGFALA2FeCNYf31Z5CglEeKX6dUMgL7y33SIw==}
+
+  '@amplitude/plugin-autocapture-browser@1.27.2':
+    resolution: {integrity: sha512-UTA/0IDw/f2nnK+S1XILqoI5pgUgMTEZokDS6+pC4wuYtmOS9uNAgKuyajzjW12uobybMHRpv7xLjCJ5khKGAg==}
+
+  '@amplitude/plugin-custom-enrichment-browser@0.1.9':
+    resolution: {integrity: sha512-wemh2Tw3zgQ7sa7MUNyMGz9OR6VjTG4tlAMrLlDKbQ4tVkgNI3oAwOF7+0BA8qzgeMXX6iw+CEKaE+EC/okkuQ==}
+
+  '@amplitude/plugin-event-property-attribution-browser@0.2.1':
+    resolution: {integrity: sha512-xqBCZe0DYsKyQ1eELN2LM8adXwRE2eOi3SnvSu9SkS0GDXBYWinuPCuLqyc/3uD5hY2FLACWvakpU0tr7GDJgg==}
+
+  '@amplitude/plugin-experiment-browser@1.0.0-beta.28':
+    resolution: {integrity: sha512-NQz267zLi7vl2G2lx10yUrEoGOCe5K9iqcPSIjbTavGu/XGvsmqLDqBHhg+EkdEMAPwypoXnmtPEs3RMhX+1MA==}
+
+  '@amplitude/plugin-network-capture-browser@1.10.1':
+    resolution: {integrity: sha512-jROIAkUDPd25A/t8W5MpmsTiBat2qoJbCMoNBKKxLMNEaE8VYbheflByWLkm4enbHgWS7OveWy0i3Oc7uPCfAg==}
+
+  '@amplitude/plugin-page-url-enrichment-browser@0.7.11':
+    resolution: {integrity: sha512-u9JhUP/VenJifCSbdTz2YZZiXAphs3efzd+qx1SRAIU6d1swPh0g/GVw3sTwvH+4MZtw3SwVC1OFxmz+f2QVyA==}
+
+  '@amplitude/plugin-page-view-tracking-browser@2.11.1':
+    resolution: {integrity: sha512-tfXg6Uir6X1XuWsOOXE/EgZ9NvM7i2ktDdagydSrFN6OyVkMvqdjPKUZSSUPuHtOoomboi3WaZsTUfq1jkWP3w==}
+
+  '@amplitude/plugin-session-replay-browser@1.31.0':
+    resolution: {integrity: sha512-b7kyYVEdW3EMR6cPXCfld+h8nQsuAR5o6vum8Glu+ofhFDfG4wj/mTJ0ITEaNbsJCfXniKQ3kFgTe6hTtxSFGQ==}
+
+  '@amplitude/plugin-web-vitals-browser@1.1.33':
+    resolution: {integrity: sha512-33FzxMH1Lr2lhvr5DDy3xD1HHWEI4KPLQsMUXqDTldkLl/ENNeBWcsljQTTDJipmRdS32I79KJhuHRNaoXd6fg==}
+
+  '@amplitude/rrdom@2.1.0':
+    resolution: {integrity: sha512-2dAtxXL02usBV2CSOnScLd3WoVqWaeiGpxN8LuXJ0r/NpLJkW1k876v2tRKAz5NrxPwSdjihsMmwCIXHpJhHfA==}
+
+  '@amplitude/rrweb-packer@2.0.0-alpha.40':
+    resolution: {integrity: sha512-Btb6b9pS1IvDMbvyYxpUdTk9NRJugSoJjRCl7R6jP/iSlPWXoveJIwHaNFAS9ZmWUEK7HhyBJ8bKGFN3giUsDg==}
+
+  '@amplitude/rrweb-plugin-console-record@2.0.0-alpha.40':
+    resolution: {integrity: sha512-vtY7T/kGFl62nC1u7ZUXQvU7ulB70cZGVHPRN/SO9fzVfsY7y6rCmBfoc2jS5KmISdlgkVzMjY2r/EE2Gk9AQA==}
+    peerDependencies:
+      '@amplitude/rrweb': ^2.0.0-alpha.40
+
+  '@amplitude/rrweb-record@2.0.0-alpha.40':
+    resolution: {integrity: sha512-5cJhQwzhymJWX5/XOtpWK0h2NLq9+t2YiO6ub0cdZ9F5AZizaRbsVH88int07DfX0YiXTKWbISezVuduCLqgSQ==}
+
+  '@amplitude/rrweb-snapshot@2.1.0':
+    resolution: {integrity: sha512-xYQvOW73ig+5M7caqilA8j0S6MHWUULLeJNK+2VVvUqv8mr4FMT2DUAQiVBGCImNlb9Gu2rLUfCScMnVxn+EDg==}
+
+  '@amplitude/rrweb-types@2.0.0-alpha.40':
+    resolution: {integrity: sha512-rP7CBDkzXupxOA7ukvC+zDYLuCtsz54TuJKC4+5O72Jsz4YdokLznKZRG34P6zXozfhGU0261qckk87lLY6mKQ==}
+
+  '@amplitude/rrweb-types@2.1.0':
+    resolution: {integrity: sha512-S73tBI/04A6HCHgnrUNeeVOvnDTEoQnNrmZGyrZncJwRlTIX+6BQSYtBFofMag8GnAy9gA+NtC0TL0CnluOWBw==}
+
+  '@amplitude/rrweb-utils@2.0.0-alpha.40':
+    resolution: {integrity: sha512-i1CCt6MCjlqoeNc+1Hse5bz+ZbASaWaIJ0WdJZvnQjUCHH29Xy/QFouyOuor73RZ+UWX4s2tYSrUIdmBepXk3w==}
+
+  '@amplitude/rrweb-utils@2.1.0':
+    resolution: {integrity: sha512-dTCDnSiMMHZ10utYHJ8dSd/xkjFgdF67y74PkOzAPcCKW1rLxyJYcFOA3uPL2b7cIVVmoel/5NTp5eflaUaJfQ==}
+
+  '@amplitude/rrweb@2.1.1':
+    resolution: {integrity: sha512-6uA+5VE/VHumaXPXTTLGRogd/K9MDwd01jGteppeLzsX0PvqlDyY5aIi35yh9+q1iS6ciPBn/2NRg0lg4cFIlw==}
+
+  '@amplitude/session-replay-browser@1.44.0':
+    resolution: {integrity: sha512-8Ruep2TTDMcfVMKurSpBbVclBK/v8Lb3aSHFsYd/xOQ1E3CaKoAu39pplli28NWoUcW7unyVE7khkOa2zzn0Lw==}
+
+  '@amplitude/targeting@0.2.0':
+    resolution: {integrity: sha512-/50ywTrC4hfcfJVBbh5DFbqMPPfaIOivZeb5Gb+OGM03QrA+lsUqdvtnKLNuWtceD4H6QQ2KFzPJ5aAJLyzVDA==}
+
+  '@amplitude/ua-parser-js@0.7.33':
+    resolution: {integrity: sha512-wKEtVR4vXuPT9cVEIJkYWnlF++Gx3BdLatPBM+SZ1ztVIvnhdGBZR/mn9x/PzyrMcRlZmyi6L56I2J3doVBnjA==}
+
+  '@amplitude/unified@1.1.11':
+    resolution: {integrity: sha512-HXB5xNXkD3POreiRXkt9WiSr6o+2cJaLfFAw02TQDyvdfmO9oiLtFVjM8EP8GY0Of5zZKcWNGMCzE+l3JLDRyw==}
 
   '@asamuzakjp/css-color@3.2.0':
     resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
@@ -1698,6 +1802,15 @@ packages:
       rollup:
         optional: true
 
+  '@rollup/plugin-replace@6.0.3':
+    resolution: {integrity: sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
+
   '@rollup/pluginutils@5.3.0':
     resolution: {integrity: sha512-5EdhGZtnu3V88ces7s53hhfK5KSASnJZv8Lulpc04cWO3REESroJXg73DFsOmgbU2BhwV0E20bu2IDZb3VKW4Q==}
     engines: {node: '>=14.0.0'}
@@ -2385,6 +2498,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/css-font-loading-module@0.0.7':
+    resolution: {integrity: sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -2455,6 +2571,9 @@ packages:
 
   '@types/yargs@17.0.35':
     resolution: {integrity: sha512-qUHkeCyQFxMXg79wQfTtfndEC+N9ZZg76HJftDJp+qH2tV7Gj4OJi7l+PiWwJ+pWtW8GwSmqsDj/oymhrTWXjg==}
+
+  '@types/zen-observable@0.8.3':
+    resolution: {integrity: sha512-fbF6oTd4sGGy0xjHPKAt+eS2CrxJ3+6gQ3FGcBoIJR2TLAyCkCyI8JqZNy+FeON0AhVgNJoUumVoZQjBFUqHkw==}
 
   '@typescript-eslint/eslint-plugin@8.57.2':
     resolution: {integrity: sha512-NZZgp0Fm2IkD+La5PR81sd+g+8oS6JwJje+aRWsDocxHkjyRw0J5L5ZTlN3LI1LlOcGL7ph3eaIUmTXMIjLk0w==}
@@ -2709,6 +2828,9 @@ packages:
   '@webassemblyjs/wast-printer@1.14.1':
     resolution: {integrity: sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==}
 
+  '@xstate/fsm@1.6.5':
+    resolution: {integrity: sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==}
+
   '@xtuc/ieee754@1.2.0':
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
 
@@ -2927,6 +3049,13 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+
+  base64-js@1.5.1:
+    resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
   baseline-browser-mapping@2.10.11:
     resolution: {integrity: sha512-DAKrHphkJyiGuau/cFieRYhcTFeK/lBuD++C7cZ6KZHbMhBrisoi+EvhQ5RZrIfV5qwsW8kgQ07JIC+MDJRAhg==}
@@ -3665,6 +3794,9 @@ packages:
       picomatch:
         optional: true
 
+  fflate@0.4.8:
+    resolution: {integrity: sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==}
+
   file-entry-cache@8.0.0:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
@@ -3865,6 +3997,12 @@ packages:
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
+
+  idb-keyval@6.2.5:
+    resolution: {integrity: sha512-eKQkTnS0relYsSOYomx8ozIbmdsQCKUdhyuIaQ2DZgKuaxtyQQMkyD/wlnQN32pO3yutN1b1L8uqwcDKaJd7/Q==}
+
+  idb@8.0.0:
+    resolution: {integrity: sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -4235,6 +4373,9 @@ packages:
   jju@1.4.0:
     resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
+  js-base64@3.7.8:
+    resolution: {integrity: sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -4518,6 +4659,9 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  mitt@3.0.1:
+    resolution: {integrity: sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==}
 
   mlly@1.8.2:
     resolution: {integrity: sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==}
@@ -5013,6 +5157,9 @@ packages:
     resolution: {integrity: sha512-AURm5f0jYEOydBj7VQlVvDrjeFgthDdEF5H1dP+6mNpoXOMo1quQqJ4wvJDyRZ9+pO3kGWoOdmV08cSv2aJV6Q==}
     engines: {node: '>=0.4'}
 
+  safe-json-stringify@1.2.0:
+    resolution: {integrity: sha512-gH8eh2nZudPQO6TytOvbxnuhYBOvDBBLW52tz5q6X58lJcd/tkmqFR+5Z9adS8aJtURSXWThWy/xJtJwixErvg==}
+
   safe-push-apply@1.0.0:
     resolution: {integrity: sha512-iKE9w/Z7xCzUMIZqdBsp6pEQvwuEebH4vdpjcDWnyzaI6yl6O9FHvVpmGelvEHNsoY6wGblkxR6Zty/h00WiSA==}
     engines: {node: '>= 0.4'}
@@ -5454,6 +5601,9 @@ packages:
   undici-types@7.25.0:
     resolution: {integrity: sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==}
 
+  unfetch@4.1.0:
+    resolution: {integrity: sha512-crP/n3eAPUJxZXM9T80/yv0YhkTEx2K1D3h7D1AJM6fzsWZrxdyRuLN0JH/dkZh1LNH8LxCnBzoPFCPbb2iGpg==}
+
   unicode-canonical-property-names-ecmascript@2.0.1:
     resolution: {integrity: sha512-dA8WbNeb2a6oQzAQ55YlT5vQAWGV9WXOsi3SskE3bcCdM0P4SDd+24zS/OCacdRq5BkdsRj9q3Pg6YyQoxIGqg==}
     engines: {node: '>=4'}
@@ -5572,6 +5722,9 @@ packages:
   watchpack@2.5.1:
     resolution: {integrity: sha512-Zn5uXdcFNIA1+1Ei5McRd+iRzfhENPCe7LeABkJtNulSxjma+l7ltNx55BWZkRlwRnpOgHqxnjyaDgJnNXnqzg==}
     engines: {node: '>=10.13.0'}
+
+  web-vitals@5.1.0:
+    resolution: {integrity: sha512-ArI3kx5jI0atlTtmV0fWU3fjpLmq/nD3Zr1iFFlJLaqa5wLBkUSzINwBPySCX/8jRyjlmy1Volw1kz1g9XE4Jg==}
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
@@ -5694,6 +5847,9 @@ packages:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zen-observable@0.10.0:
+    resolution: {integrity: sha512-iI3lT0iojZhKwT5DaFy2Ce42n3yFcLdFyOh01G7H0flMY60P8MJuVFEoJoNwXlmAyQ45GrjL6AcZmmlv8A5rbw==}
+
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
@@ -5729,6 +5885,196 @@ snapshots:
   '@adobe/css-tools@4.4.4': {}
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@amplitude/analytics-browser@2.42.5':
+    dependencies:
+      '@amplitude/analytics-core': 2.48.2
+      '@amplitude/plugin-autocapture-browser': 1.27.2
+      '@amplitude/plugin-custom-enrichment-browser': 0.1.9
+      '@amplitude/plugin-event-property-attribution-browser': 0.2.1
+      '@amplitude/plugin-network-capture-browser': 1.10.1
+      '@amplitude/plugin-page-url-enrichment-browser': 0.7.11
+      '@amplitude/plugin-page-view-tracking-browser': 2.11.1
+      '@amplitude/plugin-web-vitals-browser': 1.1.33
+      tslib: 2.8.1
+
+  '@amplitude/analytics-client-common@2.4.48':
+    dependencies:
+      '@amplitude/analytics-connector': 1.6.4
+      '@amplitude/analytics-core': 2.48.2
+      '@amplitude/analytics-types': 2.11.1
+      tslib: 2.8.1
+
+  '@amplitude/analytics-connector@1.6.4': {}
+
+  '@amplitude/analytics-core@2.48.2':
+    dependencies:
+      '@amplitude/analytics-connector': 1.6.4
+      '@types/zen-observable': 0.8.3
+      safe-json-stringify: 1.2.0
+      tslib: 2.8.1
+      zen-observable: 0.10.0
+
+  '@amplitude/analytics-types@1.4.0': {}
+
+  '@amplitude/analytics-types@2.11.1': {}
+
+  '@amplitude/engagement-browser@1.0.10':
+    dependencies:
+      '@amplitude/analytics-types': 1.4.0
+
+  '@amplitude/experiment-core@0.13.1':
+    dependencies:
+      js-base64: 3.7.8
+
+  '@amplitude/experiment-core@0.7.2':
+    dependencies:
+      js-base64: 3.7.8
+
+  '@amplitude/experiment-js-client@1.21.1':
+    dependencies:
+      '@amplitude/analytics-connector': 1.6.4
+      '@amplitude/experiment-core': 0.13.1
+      '@amplitude/ua-parser-js': 0.7.33
+      base64-js: 1.5.1
+      unfetch: 4.1.0
+
+  '@amplitude/plugin-autocapture-browser@1.27.2':
+    dependencies:
+      '@amplitude/analytics-core': 2.48.2
+      tslib: 2.8.1
+
+  '@amplitude/plugin-custom-enrichment-browser@0.1.9':
+    dependencies:
+      '@amplitude/analytics-core': 2.48.2
+      tslib: 2.8.1
+
+  '@amplitude/plugin-event-property-attribution-browser@0.2.1':
+    dependencies:
+      '@amplitude/analytics-core': 2.48.2
+      tslib: 2.8.1
+
+  '@amplitude/plugin-experiment-browser@1.0.0-beta.28':
+    dependencies:
+      '@amplitude/analytics-core': 2.48.2
+      '@amplitude/experiment-js-client': 1.21.1
+
+  '@amplitude/plugin-network-capture-browser@1.10.1':
+    dependencies:
+      '@amplitude/analytics-core': 2.48.2
+      tslib: 2.8.1
+
+  '@amplitude/plugin-page-url-enrichment-browser@0.7.11':
+    dependencies:
+      '@amplitude/analytics-core': 2.48.2
+      tslib: 2.8.1
+
+  '@amplitude/plugin-page-view-tracking-browser@2.11.1':
+    dependencies:
+      '@amplitude/analytics-core': 2.48.2
+      tslib: 2.8.1
+
+  '@amplitude/plugin-session-replay-browser@1.31.0(@amplitude/rrweb@2.1.1)(rollup@4.61.0)':
+    dependencies:
+      '@amplitude/analytics-client-common': 2.4.48
+      '@amplitude/analytics-core': 2.48.2
+      '@amplitude/analytics-types': 2.11.1
+      '@amplitude/rrweb-plugin-console-record': 2.0.0-alpha.40(@amplitude/rrweb@2.1.1)
+      '@amplitude/rrweb-record': 2.0.0-alpha.40
+      '@amplitude/session-replay-browser': 1.44.0(@amplitude/rrweb@2.1.1)(rollup@4.61.0)
+      idb-keyval: 6.2.5
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@amplitude/rrweb'
+      - rollup
+
+  '@amplitude/plugin-web-vitals-browser@1.1.33':
+    dependencies:
+      '@amplitude/analytics-core': 2.48.2
+      tslib: 2.8.1
+      web-vitals: 5.1.0
+
+  '@amplitude/rrdom@2.1.0':
+    dependencies:
+      '@amplitude/rrweb-snapshot': 2.1.0
+
+  '@amplitude/rrweb-packer@2.0.0-alpha.40':
+    dependencies:
+      '@amplitude/rrweb-types': 2.0.0-alpha.40
+      fflate: 0.4.8
+
+  '@amplitude/rrweb-plugin-console-record@2.0.0-alpha.40(@amplitude/rrweb@2.1.1)':
+    dependencies:
+      '@amplitude/rrweb': 2.1.1
+
+  '@amplitude/rrweb-record@2.0.0-alpha.40':
+    dependencies:
+      '@amplitude/rrweb': 2.1.1
+      '@amplitude/rrweb-types': 2.1.0
+
+  '@amplitude/rrweb-snapshot@2.1.0':
+    dependencies:
+      postcss: 8.5.8
+
+  '@amplitude/rrweb-types@2.0.0-alpha.40': {}
+
+  '@amplitude/rrweb-types@2.1.0': {}
+
+  '@amplitude/rrweb-utils@2.0.0-alpha.40': {}
+
+  '@amplitude/rrweb-utils@2.1.0': {}
+
+  '@amplitude/rrweb@2.1.1':
+    dependencies:
+      '@amplitude/rrdom': 2.1.0
+      '@amplitude/rrweb-snapshot': 2.1.0
+      '@amplitude/rrweb-types': 2.1.0
+      '@amplitude/rrweb-utils': 2.1.0
+      '@types/css-font-loading-module': 0.0.7
+      '@xstate/fsm': 1.6.5
+      base64-arraybuffer: 1.0.2
+      mitt: 3.0.1
+
+  '@amplitude/session-replay-browser@1.44.0(@amplitude/rrweb@2.1.1)(rollup@4.61.0)':
+    dependencies:
+      '@amplitude/analytics-client-common': 2.4.48
+      '@amplitude/analytics-core': 2.48.2
+      '@amplitude/analytics-types': 2.11.1
+      '@amplitude/experiment-core': 0.7.2
+      '@amplitude/rrweb-packer': 2.0.0-alpha.40
+      '@amplitude/rrweb-plugin-console-record': 2.0.0-alpha.40(@amplitude/rrweb@2.1.1)
+      '@amplitude/rrweb-record': 2.0.0-alpha.40
+      '@amplitude/rrweb-types': 2.0.0-alpha.40
+      '@amplitude/rrweb-utils': 2.0.0-alpha.40
+      '@amplitude/targeting': 0.2.0
+      '@rollup/plugin-replace': 6.0.3(rollup@4.61.0)
+      idb: 8.0.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - '@amplitude/rrweb'
+      - rollup
+
+  '@amplitude/targeting@0.2.0':
+    dependencies:
+      '@amplitude/analytics-client-common': 2.4.48
+      '@amplitude/analytics-core': 2.48.2
+      '@amplitude/analytics-types': 2.11.1
+      '@amplitude/experiment-core': 0.7.2
+      idb: 8.0.0
+      tslib: 2.8.1
+
+  '@amplitude/ua-parser-js@0.7.33': {}
+
+  '@amplitude/unified@1.1.11(@amplitude/rrweb@2.1.1)(rollup@4.61.0)':
+    dependencies:
+      '@amplitude/analytics-browser': 2.42.5
+      '@amplitude/analytics-core': 2.48.2
+      '@amplitude/engagement-browser': 1.0.10
+      '@amplitude/plugin-experiment-browser': 1.0.0-beta.28
+      '@amplitude/plugin-session-replay-browser': 1.31.0(@amplitude/rrweb@2.1.1)(rollup@4.61.0)
+    transitivePeerDependencies:
+      - '@amplitude/rrweb'
+      - rollup
 
   '@asamuzakjp/css-color@3.2.0':
     dependencies:
@@ -7281,6 +7627,13 @@ snapshots:
     optionalDependencies:
       rollup: 4.61.0
 
+  '@rollup/plugin-replace@6.0.3(rollup@4.61.0)':
+    dependencies:
+      '@rollup/pluginutils': 5.3.0(rollup@4.61.0)
+      magic-string: 0.30.21
+    optionalDependencies:
+      rollup: 4.61.0
+
   '@rollup/pluginutils@5.3.0(rollup@4.61.0)':
     dependencies:
       '@types/estree': 1.0.8
@@ -7962,6 +8315,8 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/css-font-loading-module@0.0.7': {}
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
@@ -8034,6 +8389,8 @@ snapshots:
   '@types/yargs@17.0.35':
     dependencies:
       '@types/yargs-parser': 21.0.3
+
+  '@types/zen-observable@0.8.3': {}
 
   '@typescript-eslint/eslint-plugin@8.57.2(@typescript-eslint/parser@8.57.2(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3)':
     dependencies:
@@ -8333,6 +8690,8 @@ snapshots:
       '@webassemblyjs/ast': 1.14.1
       '@xtuc/long': 4.2.2
 
+  '@xstate/fsm@1.6.5': {}
+
   '@xtuc/ieee754@1.2.0': {}
 
   '@xtuc/long@4.2.2': {}
@@ -8592,6 +8951,10 @@ snapshots:
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  base64-arraybuffer@1.0.2: {}
+
+  base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.11: {}
 
@@ -9432,6 +9795,8 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fflate@0.4.8: {}
+
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
@@ -9637,6 +10002,10 @@ snapshots:
   iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
+
+  idb-keyval@6.2.5: {}
+
+  idb@8.0.0: {}
 
   ignore@5.3.2: {}
 
@@ -10211,6 +10580,8 @@ snapshots:
 
   jju@1.4.0: {}
 
+  js-base64@3.7.8: {}
+
   js-tokens@4.0.0: {}
 
   js-yaml@3.14.2:
@@ -10462,6 +10833,8 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.1.3: {}
+
+  mitt@3.0.1: {}
 
   mlly@1.8.2:
     dependencies:
@@ -10962,6 +11335,8 @@ snapshots:
       has-symbols: 1.1.0
       isarray: 2.0.5
 
+  safe-json-stringify@1.2.0: {}
+
   safe-push-apply@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -11438,6 +11813,8 @@ snapshots:
 
   undici-types@7.25.0: {}
 
+  unfetch@4.1.0: {}
+
   unicode-canonical-property-names-ecmascript@2.0.1: {}
 
   unicode-match-property-ecmascript@2.0.0:
@@ -11562,6 +11939,8 @@ snapshots:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
 
+  web-vitals@5.1.0: {}
+
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@7.0.0: {}
@@ -11572,7 +11951,7 @@ snapshots:
 
   webpack@5.107.2:
     dependencies:
-      '@types/estree': 1.0.8
+      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
@@ -11591,7 +11970,7 @@ snapshots:
       mime-db: 1.54.0
       neo-async: 2.6.2
       schema-utils: 4.3.3
-      tapable: 2.3.2
+      tapable: 2.3.3
       terser-webpack-plugin: 5.6.1(webpack@5.107.2)
       watchpack: 2.5.1
       webpack-sources: 3.5.0
@@ -11714,6 +12093,8 @@ snapshots:
       yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
+
+  zen-observable@0.10.0: {}
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:


### PR DESCRIPTION
## 📌 관련 이슈

- closes #184

## 📝 작업 내용

- [x] `@amplitude/unified` 패키지 설치
- [x] `Providers.tsx`에서 클라이언트 사이드 Amplitude 초기화
- [x] 커스텀 이벤트 추가

## 🔎 자세한 설명

사용자 행동 데이터를 수집하고 핵심 지표를 분석하기 위해 Amplitude Analytics를 도입했습니다.

### ✅ Amplitude 초기화

Amplitude는 클라이언트 전용 SDK이므로 `Providers.tsx`에서 한 번만 초기화합니다.

| 옵션 | 설정값 | 설명 |
| --- | --- | --- |
| `autocapture` | `true` | 클릭, 페이지 뷰, 세션 등 기본 이벤트 자동 수집 |
| `sessionReplay.sampleRate` | `0.1` | 전체 세션 중 10% 녹화 |

로컬 개발 환경에서는 이벤트가 수집되지 않도록 `process.env.NODE_ENV === 'production'` 조건에서만 초기화했습니다.

### ✅ 커스텀 이벤트 추가

Autocapture로 수집되는 기본 이벤트 외 맥락 정보가 필요한 핵심 사용자 행동을 별도 이벤트로 추가했습니다.

| 이벤트 | 발생 시점 | 속성 | 활용 |
| --- | --- | --- | --- |
| `signup_completed` | 회원가입 API 성공 | - | 가입 전환율 측정 |
| `log_created` | 로그 작성 API 성공 | - | 핵심 기능 사용량 및 작성 이탈 분석 |
| `log_updated` | 로그 수정 API 성공 | `post_id` | 수정 빈도 및 패턴 분석 |
| `like_toggled` | 좋아요 버튼 클릭 | `post_id`, `liked` | 콘텐츠 참여도 및 취소 패턴 분석 |
| `bookmark_toggled` | 북마크 반영 완료 | `post_id`, `bookmarked` | 저장 의도가 있는 콘텐츠 분석 |
| `share_clicked` | 공유 버튼 클릭 | `post_id`, `is_owner` | 외부 유입을 유발하는 콘텐츠 파악 |

#### 트래킹 제외 케이스

본인 게시글에 대한 좋아요/북마크는 실제 사용자 참여도를 왜곡할 수 있다고 판단하여 `like_toggled`, `bookmark_toggled` 이벤트를 수집하지 않습니다.

또한 `RecordTab`, `BookmarkTab`과 같은 마이페이지 영역의 인터랙션은 콘텐츠 소비보다는 개인 관리 목적에 가깝다고 판단하여 집계 대상에서 제외했습니다.

해당 동작은 `LikeButton`, `BookmarkButton`의 `disableTracking` prop으로 제어하며, 버튼의 실제 기능에는 영향을 주지 않습니다.

### ✅ 지표 활용 방안

#### 1) 퍼널 분석
- 회원가입: 로그인 페이지 진입 → `signup_completed` 완료율 분석
- 로그 작성: 작성 페이지 진입 → `log_created` 완료율 분석

#### 2) 참여도 분석
- `like_toggled`, `bookmark_toggled`를 통해 게시글별, 사용자별 참여도 측정
- Session Replay를 활용해 참여도가 낮은 화면에서의 실제 사용자 행동 확인

#### 3) 리텐션 분석
- `log_created`를 기준 이벤트로 설정하여 첫 기록 작성 이후 재방문 및 재작성 비율 추적

## 🖼️ 스크린샷

<img width="800" alt="image" src="https://github.com/user-attachments/assets/11979cff-6176-4378-beb6-3dcfe7cb2702" />

## 💬 리뷰어에게

Sentry와 마찬가지로 관련 환경 변수는 따로 공유 드리겠습니다 🙂

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
