### PR TITLE
refactor: place 엔티티 Zod 스키마 도입 및 쿼리 키 패턴 정리

### DIFF
--- a/apps/web/src/entities/place/api/client.ts
+++ b/apps/web/src/entities/place/api/client.ts
@@ -1,20 +1,20 @@
 import { clientApi } from '@/shared/api/client-api';
 
 import {
-  type RecentPlaceDeleteResponse,
-  type RecentPlaceSaveResponse,
-  type RecentPlacesResponse,
-  type SaveRecentPlaceRequest,
-} from '../model/types';
+  recentPlaceDeleteResponseSchema,
+  recentPlaceSaveResponseSchema,
+  recentPlacesResponseSchema,
+} from '../model/schemas';
+import { type SaveRecentPlaceRequest } from '../model/types';
 
 export const getRecentPlaces = () =>
-  clientApi.get<RecentPlacesResponse>('/place/recent');
+  clientApi.get('/place/recent', recentPlacesResponseSchema);
 
 export const saveRecentPlace = (data: SaveRecentPlaceRequest) =>
-  clientApi.post<RecentPlaceSaveResponse>('/place/recent', data);
+  clientApi.post('/place/recent', data, recentPlaceSaveResponseSchema);
 
 export const deleteRecentPlaces = () =>
-  clientApi.delete<RecentPlaceDeleteResponse>('/place/recent');
+  clientApi.delete('/place/recent', recentPlaceDeleteResponseSchema);
 
 export const deleteRecentPlace = (id: number) =>
-  clientApi.delete<RecentPlaceDeleteResponse>(`/place/recent/${id}`);
+  clientApi.delete(`/place/recent/${id}`, recentPlaceDeleteResponseSchema);

--- a/apps/web/src/entities/place/index.ts
+++ b/apps/web/src/entities/place/index.ts
@@ -9,12 +9,14 @@ export type { PlaceCategory, PlaceCategoryValue } from './model/place-category';
 export { PLACE_CATEGORIES } from './model/place-category';
 export { mapQueryKeys, placeQueryKeys } from './model/query-keys';
 export type {
-  MapSortType,
   Place,
-  PlaceLayer,
   RecentPlace,
   RecentPlaceDeleteResponse,
   RecentPlaceSaveResponse,
   RecentPlacesResponse,
+} from './model/schemas';
+export type {
+  MapSortType,
+  PlaceLayer,
   SaveRecentPlaceRequest,
 } from './model/types';

--- a/apps/web/src/entities/place/index.ts
+++ b/apps/web/src/entities/place/index.ts
@@ -9,7 +9,6 @@ export type { PlaceCategory, PlaceCategoryValue } from './model/place-category';
 export { PLACE_CATEGORIES } from './model/place-category';
 export { mapQueryKeys, placeQueryKeys } from './model/query-keys';
 export type {
-  Place,
   RecentPlace,
   RecentPlaceDeleteResponse,
   RecentPlaceSaveResponse,

--- a/apps/web/src/entities/place/model/query-keys.ts
+++ b/apps/web/src/entities/place/model/query-keys.ts
@@ -1,7 +1,8 @@
 import { type MapSortType, type PlaceLayer } from './types';
 
 export const placeQueryKeys = {
-  recent: ['place', 'recent'] as const,
+  all: ['place'] as const,
+  recent: () => ['place', 'recent'] as const,
 };
 
 export const mapQueryKeys = {

--- a/apps/web/src/entities/place/model/schemas.ts
+++ b/apps/web/src/entities/place/model/schemas.ts
@@ -1,21 +1,5 @@
 import { z } from 'zod';
 
-export const placeSchema = z.object({
-  id: z.number(),
-  lat: z.number(),
-  lng: z.number(),
-  name: z.string(),
-  address: z.string(),
-  imageUrl: z.string(),
-  category: z.string(),
-  recordCount: z.number().optional(),
-  bookmarkCount: z.number().optional(),
-  totalWorkHours: z.number(),
-  averageFocus: z.number(),
-});
-
-export type Place = z.infer<typeof placeSchema>;
-
 export const recentPlaceSchema = z.object({
   id: z.number(),
   placeName: z.string(),

--- a/apps/web/src/entities/place/model/schemas.ts
+++ b/apps/web/src/entities/place/model/schemas.ts
@@ -1,0 +1,51 @@
+import { z } from 'zod';
+
+export const placeSchema = z.object({
+  id: z.number(),
+  lat: z.number(),
+  lng: z.number(),
+  name: z.string(),
+  address: z.string(),
+  imageUrl: z.string(),
+  category: z.string(),
+  recordCount: z.number().optional(),
+  bookmarkCount: z.number().optional(),
+  totalWorkHours: z.number(),
+  averageFocus: z.number(),
+});
+
+export type Place = z.infer<typeof placeSchema>;
+
+export const recentPlaceSchema = z.object({
+  id: z.number(),
+  placeName: z.string(),
+  address: z.string(),
+  latitude: z.number(),
+  longitude: z.number(),
+  searchedAt: z.string(),
+});
+
+export type RecentPlace = z.infer<typeof recentPlaceSchema>;
+
+export const recentPlacesResponseSchema = z.object({
+  places: z.array(recentPlaceSchema),
+  totalCount: z.number(),
+});
+
+export type RecentPlacesResponse = z.infer<typeof recentPlacesResponseSchema>;
+
+export const recentPlaceSaveResponseSchema = z.object({
+  totalCount: z.number(),
+});
+
+export type RecentPlaceSaveResponse = z.infer<
+  typeof recentPlaceSaveResponseSchema
+>;
+
+export const recentPlaceDeleteResponseSchema = z.object({
+  deletedCount: z.number(),
+});
+
+export type RecentPlaceDeleteResponse = z.infer<
+  typeof recentPlaceDeleteResponseSchema
+>;

--- a/apps/web/src/entities/place/model/types.ts
+++ b/apps/web/src/entities/place/model/types.ts
@@ -2,45 +2,9 @@ export type PlaceLayer = 'record' | 'bookmark';
 
 export type MapSortType = 'LATEST' | 'RECORD_COUNT' | 'STUDY_TIME' | 'FOCUS';
 
-export type Place = {
-  id: number;
-  lat: number;
-  lng: number;
-  name: string;
-  address: string;
-  imageUrl: string;
-  category: string;
-  recordCount?: number;
-  bookmarkCount?: number;
-  totalWorkHours: number;
-  averageFocus: number;
-};
-
-export type RecentPlace = {
-  id: number;
-  placeName: string;
-  address: string;
-  latitude: number;
-  longitude: number;
-  searchedAt: string;
-};
-
-export type RecentPlacesResponse = {
-  places: RecentPlace[];
-  totalCount: number;
-};
-
 export type SaveRecentPlaceRequest = {
   placeName: string;
   address: string;
   latitude: number;
   longitude: number;
-};
-
-export type RecentPlaceSaveResponse = {
-  totalCount: number;
-};
-
-export type RecentPlaceDeleteResponse = {
-  deletedCount: number;
 };

--- a/apps/web/src/features/place-search/model/use-recent-places.ts
+++ b/apps/web/src/features/place-search/model/use-recent-places.ts
@@ -13,7 +13,7 @@ import {
 
 export function useRecentPlacesQuery() {
   return useQuery({
-    queryKey: placeQueryKeys.recent,
+    queryKey: placeQueryKeys.recent(),
     queryFn: getRecentPlaces,
     select: (data) => data.places,
   });
@@ -25,7 +25,7 @@ export function useSaveRecentPlaceMutation() {
   return useMutation({
     mutationFn: (place: SaveRecentPlaceRequest) => saveRecentPlace(place),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: placeQueryKeys.recent });
+      queryClient.invalidateQueries({ queryKey: placeQueryKeys.recent() });
     },
   });
 }
@@ -36,7 +36,7 @@ export function useDeleteRecentPlaceMutation() {
   return useMutation({
     mutationFn: (id: number) => deleteRecentPlace(id),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: placeQueryKeys.recent });
+      queryClient.invalidateQueries({ queryKey: placeQueryKeys.recent() });
     },
   });
 }
@@ -47,7 +47,7 @@ export function useDeleteRecentPlacesMutation() {
   return useMutation({
     mutationFn: deleteRecentPlaces,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: placeQueryKeys.recent });
+      queryClient.invalidateQueries({ queryKey: placeQueryKeys.recent() });
     },
   });
 }


### PR DESCRIPTION
## 📌 관련 이슈

- closes #192 

## 📝 작업 내용

- [x] `place` 엔티티 Zod 스키마 및 `z.infer` 타입 정의
- [x] `place` 엔티티 API 함수에 스키마 검증 적용
- [x] `placeQueryKeys` 쿼리 키 패턴 통일

## 🔎 자세한 설명

`user`, `feed` 엔티티와 동일하게 `place` 엔티티에 Zod 스키마를 도입하고 API 응답 타입을 `z.infer` 기반으로 추론하도록 변경했습니다. `placeQueryKeys`에 `all` prefix 키를 추가하고 `recent`를 함수형으로 변경해 쿼리 키 패턴을 정리했으며, 실제 사용처가 없는 `Place` 타입을 제거했습니다.

## 🖼️ 스크린샷

## 💬 리뷰어에게

## ✅ PR 체크리스트

- [x] 브랜치명이 컨벤션을 따르고 있습니다.
- [x] 기능이 잘 동작합니다.
- [x] 불필요한 `console.log`, 주석, 디버깅 코드를 제거했습니다.
